### PR TITLE
refactor!: align function names with JMESPath JEPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ jmespath_extensions = { version = "0.1", default-features = false, features = ["
 | `lower(string)` | Convert to lowercase | `lower('HELLO')` → `"hello"` |
 | `upper(string)` | Convert to uppercase | `upper('hello')` → `"HELLO"` |
 | `trim(string)` | Remove leading/trailing whitespace | `trim('  hi  ')` → `"hi"` |
-| `trim_start(string)` | Remove leading whitespace | `trim_start('  hi')` → `"hi"` |
-| `trim_end(string)` | Remove trailing whitespace | `trim_end('hi  ')` → `"hi"` |
+| `trim_left(string)` | Remove leading whitespace | `trim_left('  hi')` → `"hi"` |
+| `trim_right(string)` | Remove trailing whitespace | `trim_right('hi  ')` → `"hi"` |
 | `capitalize(string)` | Capitalize first letter | `capitalize('hello')` → `"Hello"` |
 | `title(string)` | Capitalize each word | `title('hello world')` → `"Hello World"` |
 | `split(string, delim)` | Split string into array | `split('a,b,c', ',')` → `["a","b","c"]` |
@@ -75,8 +75,8 @@ jmespath_extensions = { version = "0.1", default-features = false, features = ["
 | `pad_right(string, width, char)` | Right-pad string | `pad_right('5', 3, '0')` → `"500"` |
 | `substr(string, start, len?)` | Extract substring | `substr('hello', 1, 3)` → `"ell"` |
 | `slice(string, start, end?)` | Extract by indices | `slice('hello', 1, 4)` → `"ell"` |
-| `index_of(string, search)` | Find first occurrence | `index_of('hello', 'l')` → `2` |
-| `last_index_of(string, search)` | Find last occurrence | `last_index_of('hello', 'l')` → `3` |
+| `find_first(string, search)` | Find first occurrence | `find_first('hello', 'l')` → `2` |
+| `find_last(string, search)` | Find last occurrence | `find_last('hello', 'l')` → `3` |
 | `concat(array, sep?)` | Join strings | `concat(['a','b'], '-')` → `"a-b"` |
 | `camel_case(string)` | Convert to camelCase | `camel_case('hello_world')` → `"helloWorld"` |
 | `snake_case(string)` | Convert to snake_case | `snake_case('helloWorld')` → `"hello_world"` |
@@ -109,8 +109,8 @@ jmespath_extensions = { version = "0.1", default-features = false, features = ["
 
 | Function | Description | Example |
 |----------|-------------|---------|
-| `entries(object)` | Convert to [{key, value}] | `entries({a:1})` → `[{"key":"a","value":1}]` |
-| `from_entries(array)` | Convert [{key, value}] to object | `from_entries([{"key":"a","value":1}])` → `{"a":1}` |
+| `items(object)` | Convert to [{key, value}] | `items({a:1})` → `[{"key":"a","value":1}]` |
+| `from_items(array)` | Convert [{key, value}] to object | `from_items([{"key":"a","value":1}])` → `{"a":1}` |
 | `pick(object, keys)` | Select specific keys | `pick({a:1,b:2}, ['a'])` → `{"a":1}` |
 | `omit(object, keys)` | Exclude specific keys | `omit({a:1,b:2}, ['a'])` → `{"b":2}` |
 | `deep_merge(obj1, obj2)` | Recursively merge objects | `deep_merge({a:{b:1}}, {a:{c:2}})` |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@
 //!
 //! - [`string`] - String manipulation (`upper`, `lower`, `split`, `replace`, `camel_case`, etc.)
 //! - [`mod@array`] - Array operations (`first`, `last`, `unique`, `chunk`, `zip`, `range`, etc.)
-//! - [`object`] - Object utilities (`entries`, `pick`, `omit`, `deep_merge`, etc.)
+//! - [`object`] - Object utilities (`items`, `pick`, `omit`, `deep_merge`, etc.)
 //! - [`math`] - Math operations (`round`, `sqrt`, `pow`, `median`, `sin`, `cos`, etc.)
 //! - [`type_conv`] - Type functions (`type_of`, `is_string`, `is_empty`, `to_number`, etc.)
 //! - [`utility`] - Utilities (`now`, `default`, `if`, `coalesce`, `json_encode`, etc.)

--- a/src/object.rs
+++ b/src/object.rs
@@ -6,8 +6,8 @@
 //!
 //! | Function | Signature | Description |
 //! |----------|-----------|-------------|
-//! | [`entries`](#entries) | `entries(object) → array` | Convert to [{key, value}, ...] |
-//! | [`from_entries`](#from_entries) | `from_entries(array) → object` | Convert [{key, value}, ...] to object |
+//! | [`items`](#items) | `items(object) → array` | Convert to [{key, value}, ...] |
+//! | [`from_items`](#from_items) | `from_items(array) → object` | Convert [{key, value}, ...] to object |
 //! | [`pick`](#pick) | `pick(object, keys) → object` | Select specific keys |
 //! | [`omit`](#omit) | `omit(object, keys) → object` | Remove specific keys |
 //! | [`invert`](#invert) | `invert(object) → object` | Swap keys and values |
@@ -26,8 +26,8 @@
 //! runtime.register_builtin_functions();
 //! object::register(&mut runtime);
 //!
-//! // Get object entries
-//! let expr = runtime.compile("entries(@)").unwrap();
+//! // Get object items
+//! let expr = runtime.compile("items(@)").unwrap();
 //! let data = Variable::from_json(r#"{"a": 1, "b": 2}"#).unwrap();
 //! let result = expr.search(&data).unwrap();
 //! assert_eq!(result.as_array().unwrap().len(), 2);
@@ -35,26 +35,26 @@
 //!
 //! # Function Details
 //!
-//! ## entries
+//! ## items
 //!
 //! Converts an object to an array of `{key, value}` objects.
 //!
 //! ```text
-//! entries(object) → array
+//! items(object) → array
 //!
-//! entries({a: 1, b: 2})     → [{key: "a", value: 1}, {key: "b", value: 2}]
-//! entries({})               → []
+//! items({a: 1, b: 2})     → [{key: "a", value: 1}, {key: "b", value: 2}]
+//! items({})               → []
 //! ```
 //!
-//! ## from_entries
+//! ## from_items
 //!
 //! Converts an array of `{key, value}` objects back to an object.
 //!
 //! ```text
-//! from_entries(array) → object
+//! from_items(array) → object
 //!
-//! from_entries([{key: 'a', value: 1}, {key: 'b', value: 2}])   → {a: 1, b: 2}
-//! from_entries([])                                              → {}
+//! from_items([{key: 'a', value: 1}, {key: 'b', value: 2}])   → {a: 1, b: 2}
+//! from_items([])                                              → {}
 //! ```
 //!
 //! ## pick
@@ -150,8 +150,8 @@ use crate::define_function;
 
 /// Register all object functions with the runtime.
 pub fn register(runtime: &mut Runtime) {
-    runtime.register_function("entries", Box::new(EntriesFn::new()));
-    runtime.register_function("from_entries", Box::new(FromEntriesFn::new()));
+    runtime.register_function("items", Box::new(EntriesFn::new()));
+    runtime.register_function("from_items", Box::new(FromEntriesFn::new()));
     runtime.register_function("pick", Box::new(PickFn::new()));
     runtime.register_function("omit", Box::new(OmitFn::new()));
     runtime.register_function("invert", Box::new(InvertFn::new()));
@@ -590,9 +590,9 @@ mod tests {
     }
 
     #[test]
-    fn test_entries() {
+    fn test_items() {
         let runtime = setup_runtime();
-        let expr = runtime.compile("entries(@)").unwrap();
+        let expr = runtime.compile("items(@)").unwrap();
         let mut obj = BTreeMap::new();
         obj.insert(
             "a".to_string(),

--- a/src/string.rs
+++ b/src/string.rs
@@ -9,8 +9,8 @@
 //! | [`lower`](#lower) | `lower(string) → string` | Convert to lowercase |
 //! | [`upper`](#upper) | `upper(string) → string` | Convert to uppercase |
 //! | [`trim`](#trim) | `trim(string) → string` | Remove leading/trailing whitespace |
-//! | [`trim_start`](#trim_start) | `trim_start(string) → string` | Remove leading whitespace |
-//! | [`trim_end`](#trim_end) | `trim_end(string) → string` | Remove trailing whitespace |
+//! | [`trim_left`](#trim_left) | `trim_left(string) → string` | Remove leading whitespace |
+//! | [`trim_right`](#trim_right) | `trim_right(string) → string` | Remove trailing whitespace |
 //! | [`split`](#split) | `split(string, delimiter) → array` | Split string into array |
 //! | [`replace`](#replace) | `replace(string, old, new) → string` | Replace all occurrences |
 //! | [`pad_left`](#pad_left) | `pad_left(string, width, char) → string` | Left-pad to width |
@@ -19,8 +19,8 @@
 //! | [`capitalize`](#capitalize) | `capitalize(string) → string` | Capitalize first letter |
 //! | [`title`](#title) | `title(string) → string` | Title Case Each Word |
 //! | [`repeat`](#repeat) | `repeat(string, count) → string` | Repeat string N times |
-//! | [`index_of`](#index_of) | `index_of(string, search) → number` | Find first occurrence |
-//! | [`last_index_of`](#last_index_of) | `last_index_of(string, search) → number` | Find last occurrence |
+//! | [`find_first`](#find_first) | `find_first(string, search) → number` | Find first occurrence |
+//! | [`find_last`](#find_last) | `find_last(string, search) → number` | Find last occurrence |
 //! | [`slice`](#slice) | `slice(string, start, end?) → string` | Extract slice |
 //! | [`concat`](#concat) | `concat(array, separator?) → string` | Join array of strings |
 //! | [`camel_case`](#camel_case) | `camel_case(string) → string` | Convert to camelCase |
@@ -89,26 +89,26 @@
 //! trim('hello')       → "hello"
 //! ```
 //!
-//! ## trim_start
+//! ## trim_left
 //!
 //! Removes leading whitespace from a string.
 //!
 //! ```text
-//! trim_start(string) → string
+//! trim_left(string) → string
 //!
-//! trim_start('  hello  ') → "hello  "
-//! trim_start('\nhello')   → "hello"
+//! trim_left('  hello  ') → "hello  "
+//! trim_left('\nhello')   → "hello"
 //! ```
 //!
-//! ## trim_end
+//! ## trim_right
 //!
 //! Removes trailing whitespace from a string.
 //!
 //! ```text
-//! trim_end(string) → string
+//! trim_right(string) → string
 //!
-//! trim_end('  hello  ') → "  hello"
-//! trim_end('hello\n')   → "hello"
+//! trim_right('  hello  ') → "  hello"
+//! trim_right('hello\n')   → "hello"
 //! ```
 //!
 //! ## split
@@ -210,28 +210,28 @@
 //! repeat('hello', 0) → ""
 //! ```
 //!
-//! ## index_of
+//! ## find_first
 //!
 //! Finds the first occurrence of a substring. Returns -1 if not found.
 //!
 //! ```text
-//! index_of(string, search) → number
+//! find_first(string, search) → number
 //!
-//! index_of('hello world', 'world') → 6
-//! index_of('hello world', 'o')     → 4
-//! index_of('hello', 'x')           → -1
+//! find_first('hello world', 'world') → 6
+//! find_first('hello world', 'o')     → 4
+//! find_first('hello', 'x')           → -1
 //! ```
 //!
-//! ## last_index_of
+//! ## find_last
 //!
 //! Finds the last occurrence of a substring. Returns -1 if not found.
 //!
 //! ```text
-//! last_index_of(string, search) → number
+//! find_last(string, search) → number
 //!
-//! last_index_of('hello world', 'o') → 7
-//! last_index_of('abcabc', 'abc')    → 3
-//! last_index_of('hello', 'x')       → -1
+//! find_last('hello world', 'o') → 7
+//! find_last('abcabc', 'abc')    → 3
+//! find_last('hello', 'x')       → -1
 //! ```
 //!
 //! ## slice
@@ -349,8 +349,8 @@ pub fn register(runtime: &mut Runtime) {
     runtime.register_function("lower", Box::new(LowerFn::new()));
     runtime.register_function("upper", Box::new(UpperFn::new()));
     runtime.register_function("trim", Box::new(TrimFn::new()));
-    runtime.register_function("trim_start", Box::new(TrimStartFn::new()));
-    runtime.register_function("trim_end", Box::new(TrimEndFn::new()));
+    runtime.register_function("trim_left", Box::new(TrimStartFn::new()));
+    runtime.register_function("trim_right", Box::new(TrimEndFn::new()));
     runtime.register_function("split", Box::new(SplitFn::new()));
     runtime.register_function("replace", Box::new(ReplaceFn::new()));
     runtime.register_function("pad_left", Box::new(PadLeftFn::new()));
@@ -359,8 +359,8 @@ pub fn register(runtime: &mut Runtime) {
     runtime.register_function("capitalize", Box::new(CapitalizeFn::new()));
     runtime.register_function("title", Box::new(TitleFn::new()));
     runtime.register_function("repeat", Box::new(RepeatFn::new()));
-    runtime.register_function("index_of", Box::new(IndexOfFn::new()));
-    runtime.register_function("last_index_of", Box::new(LastIndexOfFn::new()));
+    runtime.register_function("find_first", Box::new(IndexOfFn::new()));
+    runtime.register_function("find_last", Box::new(LastIndexOfFn::new()));
     runtime.register_function("slice", Box::new(SliceFn::new()));
     runtime.register_function("concat", Box::new(ConcatFn::new()));
     runtime.register_function("upper_case", Box::new(UpperCaseFn::new()));


### PR DESCRIPTION
## Breaking Changes

This PR aligns function names with the JMESPath Enhancement Proposals (JEPs) for better compatibility with the community specification.

### String Functions (JEP-014)
| Old Name | New Name |
|----------|----------|
| `trim_start` | `trim_left` |
| `trim_end` | `trim_right` |
| `index_of` | `find_first` |
| `last_index_of` | `find_last` |

### Object Functions (JEP-013)
| Old Name | New Name |
|----------|----------|
| `entries` | `items` |
| `from_entries` | `from_items` |

Since we're pre-1.0, this is a good time to make these breaking changes to align with the spec.