### PR TITLE
fix: relax dependency versions for downstream compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ sha2 = { version = "0.10", optional = true }
 crc32fast = { version = "1.5", optional = true }
 base64 = { version = "0.22", optional = true }
 urlencoding = { version = "2.1", optional = true }
-regex = { version = "1.12", optional = true }
+regex = { version = "1.5", optional = true }
 url = { version = "2.5", optional = true }
-uuid = { version = "1.19", features = ["v4"], optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
 hex = { version = "0.4", optional = true }
-rand = { version = "0.9", optional = true }
+rand = { version = "0.8", optional = true }
 
 [features]
 default = ["full"]

--- a/src/random.rs
+++ b/src/random.rs
@@ -167,8 +167,8 @@ impl Function for RandomFn {
         self.signature.validate(args, ctx)?;
 
         use rand::Rng;
-        let mut rng = rand::rng();
-        let value: f64 = rng.random_range(0.0..1.0);
+        let mut rng = rand::thread_rng();
+        let value: f64 = rng.gen_range(0.0..1.0);
 
         Ok(Rc::new(Variable::Number(
             serde_json::Number::from_f64(value).unwrap_or_else(|| serde_json::Number::from(0)),
@@ -198,7 +198,7 @@ impl Function for ShuffleFn {
 
         use rand::seq::SliceRandom;
         let mut result: Vec<Rcvar> = arr.clone();
-        result.shuffle(&mut rand::rng());
+        result.shuffle(&mut rand::thread_rng());
 
         Ok(Rc::new(Variable::Array(result)))
     }
@@ -236,9 +236,9 @@ impl Function for SampleFn {
             )
         })? as usize;
 
-        use rand::seq::IndexedRandom;
+        use rand::seq::SliceRandom;
         let sample: Vec<Rcvar> = arr
-            .choose_multiple(&mut rand::rng(), n.min(arr.len()))
+            .choose_multiple(&mut rand::thread_rng(), n.min(arr.len()))
             .cloned()
             .collect();
 


### PR DESCRIPTION
## Summary

Relaxes dependency version constraints to allow downstream projects (like RedisJSON) to use jmespath_extensions without version conflicts.

## Changes

| Dependency | Before | After | Reason |
|------------|--------|-------|--------|
| `uuid` | `1.19` | `1` | API unchanged for `Uuid::new_v4()` |
| `rand` | `0.9` | `0.8` | Reverted to `thread_rng()`/`gen_range()` API |
| `regex` | `1.12` | `1.5` | Compatible with older versions |

## Testing

- All 40 unit tests pass
- All 18 doc tests pass
- RedisJSON builds successfully with `--features jmespath`
- 125/140 RedisJSON tests pass (15 failures are due to JEP naming changes and missing functions in the test suite, not jmespath_extensions issues)