### PR TITLE
docs: add standard badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # jmespath_extensions
 
+[![Crates.io](https://img.shields.io/crates/v/jmespath_extensions.svg)](https://crates.io/crates/jmespath_extensions)
+[![Documentation](https://docs.rs/jmespath_extensions/badge.svg)](https://docs.rs/jmespath_extensions)
+[![License](https://img.shields.io/crates/l/jmespath_extensions.svg)](https://github.com/joshrotenberg/jmespath-extensions#license)
+[![CI](https://github.com/joshrotenberg/jmespath-extensions/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/jmespath-extensions/actions/workflows/ci.yml)
+
 Extended functions for JMESPath queries in Rust.
 
 > **Warning: Non-Standard Extension**


### PR DESCRIPTION
Adds standard badges to the README:

- **Crates.io** - version badge linking to crates.io
- **Documentation** - docs.rs badge linking to documentation  
- **License** - license badge
- **CI** - GitHub Actions CI status badge