### PR TITLE
refactor: add error helper functions and improve error messages

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,9 +1,88 @@
 //! Common types and utilities for JMESPath extension functions.
+//!
+//! This module provides helper functions and re-exports for implementing custom JMESPath functions.
+//!
+//! # Error Handling
+//!
+//! When implementing custom functions, use these helpers for consistent error messages:
+//!
+//! - [`invalid_type_error`] - For type mismatches (produces structured `RuntimeError::InvalidType`)
+//! - [`custom_error`] - For domain-specific errors (e.g., "Invalid regex pattern")
+//!
+//! ## Example
+//!
+//! ```ignore
+//! impl Function for MyFn {
+//!     fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+//!         self.signature.validate(args, ctx)?;
+//!
+//!         // After signature validation, type checks are guaranteed to pass.
+//!         // Use unwrap() for validated types, or invalid_type_error() for custom validation.
+//!         let s = args[0].as_string().unwrap();
+//!
+//!         // For domain-specific errors:
+//!         if s.is_empty() {
+//!             return Err(custom_error(ctx, "String cannot be empty"));
+//!         }
+//!
+//!         Ok(Rc::new(Variable::String(s.to_uppercase())))
+//!     }
+//! }
+//! ```
 
 use std::rc::Rc;
 
+pub use jmespath::RuntimeError;
 pub use jmespath::functions::{ArgumentType, Function, Signature};
 pub use jmespath::{Context, ErrorReason, JmespathError, Rcvar, Runtime, Variable};
+
+/// Creates a JmespathError for an invalid argument type.
+///
+/// This produces a structured `RuntimeError::InvalidType` error which provides
+/// better debugging information than a generic parse error string.
+///
+/// # Arguments
+/// * `ctx` - The evaluation context
+/// * `position` - The argument position (0-indexed)
+/// * `expected` - Description of the expected type(s)
+/// * `actual` - The actual value that was provided
+///
+/// # Example
+/// ```ignore
+/// let err = invalid_type_error(ctx, 0, "string", &args[0]);
+/// ```
+pub fn invalid_type_error(
+    ctx: &Context<'_>,
+    position: usize,
+    expected: &str,
+    actual: &Rcvar,
+) -> JmespathError {
+    JmespathError::from_ctx(
+        ctx,
+        ErrorReason::Runtime(RuntimeError::InvalidType {
+            expected: expected.to_owned(),
+            actual: actual.get_type().to_string(),
+            position,
+        }),
+    )
+}
+
+/// Creates a JmespathError for a custom runtime error message.
+///
+/// Use this for domain-specific errors that don't fit the standard error types,
+/// such as "Invalid regex pattern" or "Division by zero".
+///
+/// # Arguments
+/// * `ctx` - The evaluation context
+/// * `message` - A descriptive error message
+///
+/// # Example
+/// ```ignore
+/// let err = custom_error(ctx, "Invalid regex pattern: unclosed group");
+/// ```
+pub fn custom_error(ctx: &Context<'_>, message: &str) -> JmespathError {
+    JmespathError::from_ctx(ctx, ErrorReason::Parse(message.to_owned()))
+}
 
 /// Helper macro for defining JMESPath custom functions.
 ///

--- a/src/regex_fns.rs
+++ b/src/regex_fns.rs
@@ -120,7 +120,7 @@
 use std::rc::Rc;
 
 use crate::common::{
-    ArgumentType, Context, ErrorReason, Function, JmespathError, Rcvar, Runtime, Variable,
+    ArgumentType, Context, Function, JmespathError, Rcvar, Runtime, Variable, custom_error,
 };
 use crate::define_function;
 
@@ -147,29 +147,12 @@ impl Function for RegexMatchFn {
     fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
         self.signature.validate(args, ctx)?;
 
-        let input = args[0].as_string().ok_or_else(|| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Expected string argument".to_owned()),
-            )
-        })?;
+        // Safe to unwrap after signature validation
+        let input = args[0].as_string().unwrap();
+        let pattern = args[1].as_string().unwrap();
 
-        let pattern = args[1].as_string().ok_or_else(|| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Expected pattern string".to_owned()),
-            )
-        })?;
-
-        let re = Regex::new(pattern).map_err(|_| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Invalid regex pattern".to_owned()),
-            )
-        })?;
+        let re = Regex::new(pattern)
+            .map_err(|e| custom_error(ctx, &format!("Invalid regex pattern: {e}")))?;
 
         Ok(Rc::new(Variable::Bool(re.is_match(input))))
     }
@@ -189,29 +172,12 @@ impl Function for RegexExtractFn {
     fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
         self.signature.validate(args, ctx)?;
 
-        let input = args[0].as_string().ok_or_else(|| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Expected string argument".to_owned()),
-            )
-        })?;
+        // Safe to unwrap after signature validation
+        let input = args[0].as_string().unwrap();
+        let pattern = args[1].as_string().unwrap();
 
-        let pattern = args[1].as_string().ok_or_else(|| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Expected pattern string".to_owned()),
-            )
-        })?;
-
-        let re = Regex::new(pattern).map_err(|_| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Invalid regex pattern".to_owned()),
-            )
-        })?;
+        let re = Regex::new(pattern)
+            .map_err(|e| custom_error(ctx, &format!("Invalid regex pattern: {e}")))?;
 
         let matches: Vec<Rcvar> = re
             .find_iter(input)
@@ -245,37 +211,13 @@ impl Function for RegexReplaceFn {
     fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
         self.signature.validate(args, ctx)?;
 
-        let input = args[0].as_string().ok_or_else(|| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Expected string argument".to_owned()),
-            )
-        })?;
+        // Safe to unwrap after signature validation
+        let input = args[0].as_string().unwrap();
+        let pattern = args[1].as_string().unwrap();
+        let replacement = args[2].as_string().unwrap();
 
-        let pattern = args[1].as_string().ok_or_else(|| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Expected pattern string".to_owned()),
-            )
-        })?;
-
-        let replacement = args[2].as_string().ok_or_else(|| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Expected replacement string".to_owned()),
-            )
-        })?;
-
-        let re = Regex::new(pattern).map_err(|_| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Invalid regex pattern".to_owned()),
-            )
-        })?;
+        let re = Regex::new(pattern)
+            .map_err(|e| custom_error(ctx, &format!("Invalid regex pattern: {e}")))?;
 
         let result = re.replace_all(input, replacement);
         Ok(Rc::new(Variable::String(result.into_owned())))

--- a/src/string.rs
+++ b/src/string.rs
@@ -1332,7 +1332,7 @@ impl Function for WrapFn {
         if !s.ends_with('\n')
             && lines
                 .last()
-                .map_or(false, |l| l.as_string().map_or(false, |s| s.is_empty()))
+                .is_some_and(|l| l.as_string().is_some_and(|s| s.is_empty()))
         {
             lines.pop();
         }


### PR DESCRIPTION
## Summary

This PR adds helper functions for creating consistent error messages and demonstrates an improved pattern for error handling in extension functions.

## Changes

### New helper functions in `common.rs`

- **`invalid_type_error(ctx, position, expected, actual)`** - Creates a structured `RuntimeError::InvalidType` error with position, expected type, and actual type information
- **`custom_error(ctx, message)`** - Creates a domain-specific error with a custom message

### Updated `regex_fns.rs` as an example

- Simplified code by using `.unwrap()` after signature validation (types are guaranteed correct)
- Improved regex error messages to include the actual regex parse error for better debugging:
  - Before: `"Invalid regex pattern"`
  - After: `"Invalid regex pattern: regex parse error: ..."`

## Investigation Results

The jmespath.rs library provides:
- `ErrorReason::Parse(String)` - generic string errors
- `ErrorReason::Runtime(RuntimeError)` - structured runtime errors including `InvalidType`, `TooManyArguments`, `NotEnoughArguments`, etc.

The signature validation (`self.signature.validate(args, ctx)?`) already produces proper `RuntimeError::InvalidType` errors, making our manual type checks after validation redundant. However, we kept them as safety measures in existing code.

## Recommended Pattern

```rust
impl Function for MyFn {
    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
        self.signature.validate(args, ctx)?;
        
        // Safe to unwrap after signature validation
        let s = args[0].as_string().unwrap();
        
        // For domain-specific errors, use custom_error with details:
        let re = Regex::new(pattern)
            .map_err(|e| custom_error(ctx, &format!("Invalid regex: {e}")))?;
        
        Ok(...)
    }
}
```

## Notes

- This is a minimal change that adds the infrastructure and demonstrates the pattern
- Existing functions continue to work unchanged
- Future code can adopt the new pattern for cleaner, more informative errors