### PR TITLE
feat: add standard functions and JEP references to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ See the [API documentation](https://docs.rs/jmespath_extensions) for complete fu
 
 This crate aligns with several [JMESPath Enhancement Proposals](https://github.com/jmespath-community/jmespath.spec):
 
-- **JEP-014** (String Functions): `lower`, `upper`, `trim`, `pad_left`, `pad_right`, `replace`, `split`, `find_first`, `find_last`
+- **JEP-014** (String Functions): `lower`, `upper`, `trim`, `trim_left`, `trim_right`, `pad_left`, `pad_right`, `replace`, `split`, `find_first`, `find_last`
 - **JEP-013** (Object Functions): `items`, `from_items`, `zip`
+
+Functions that align with JEPs have `jep: Some("JEP-XXX")` in their `FunctionInfo` metadata, accessible via the registry.
 
 Additional functions extend well beyond these proposals. Some JEPs (like arithmetic operators) require parser changes and cannot be implemented as extension functions.
 

--- a/examples/jpx/src/main.rs
+++ b/examples/jpx/src/main.rs
@@ -214,6 +214,9 @@ fn describe_function(registry: &FunctionRegistry, func_name: &str) -> Result<()>
         }
     );
     println!("Category:    {}", func.category.name());
+    if let Some(jep) = func.jep {
+        println!("JEP:         {}", jep);
+    }
     println!("Description: {}", func.description);
     println!("Signature:   {}", func.signature);
     println!();


### PR DESCRIPTION
## Summary

Extends the FunctionRegistry with standard JMESPath function metadata and JEP alignment tracking.

## Changes

### Standard Functions Support
- Add `Category::Standard` with all 26 standard JMESPath built-in functions
- Add `is_standard: bool` field to `FunctionInfo` to distinguish standard vs extension
- Standard functions are for introspection only (actual registration via `register_builtin_functions()`)

### JEP Alignment
- Add `jep: Option<&'static str>` field to `FunctionInfo`
- Tag JEP-014 functions (11): `upper`, `lower`, `trim`, `trim_left`, `trim_right`, `split`, `replace`, `pad_left`, `pad_right`, `find_first`, `find_last`
- Tag JEP-013 functions (3): `items`, `from_items`, `zip`

### jpx CLI Updates
- `--list-functions` now shows standard (26) and extension (189) counts separately
- `--describe` shows Type (standard/extension) and JEP reference when available
- `--list-category standard` lists all standard JMESPath functions

### Documentation
- Updated registry module docs explaining standard vs extension behavior
- Updated README with JEP alignment info and function counts

## Example

```bash
$ jpx --describe upper
upper
=====

Type:        extension
Category:    string
JEP:         JEP-014
Description: Convert string to uppercase
Signature:   string -> string

Example:
  upper('hello') -> "HELLO"
```
