### PR TITLE
fix: specify benchmark name in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,4 +134,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run benchmarks
-        run: cargo bench --all-features -- --noplot
+        run: cargo bench --all-features --bench functions -- --noplot


### PR DESCRIPTION
The `--noplot` flag was being passed to all tests, not just the criterion benchmark. This adds `--bench functions` to target only the benchmark.