### PR TITLE
feat: add jpx CLI enhancements and json_pointer function

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1438,6 +1438,24 @@ fn utility_functions() -> Vec<FunctionInfo> {
             is_standard: false,
             jep: None,
         },
+        FunctionInfo {
+            name: "json_encode",
+            category: Category::Utility,
+            description: "Serialize value to JSON string",
+            signature: "any -> string",
+            example: "json_encode({a: 1}) -> \"{\\\"a\\\":1}\"",
+            is_standard: false,
+            jep: None,
+        },
+        FunctionInfo {
+            name: "json_pointer",
+            category: Category::Utility,
+            description: "Access value using JSON Pointer (RFC 6901)",
+            signature: "any, string -> any",
+            example: "json_pointer({foo: {bar: 1}}, '/foo/bar') -> 1",
+            is_standard: false,
+            jep: None,
+        },
     ]
 }
 


### PR DESCRIPTION
## Summary
Adds key usability improvements to jpx and a new utility function.

## Changes

### jpx CLI
- **`-n` / `--null-input`**: Run expressions without input data, perfect for generator functions
  ```bash
  jpx -n 'uuid()'
  jpx -n 'now()'
  jpx -n 'range(`1`, `10`)'
  ```

- **`-s` / `--slurp`**: Read multiple JSON values into an array (NDJSON support)
  ```bash
  echo '{"name":"alice"}
  {"name":"bob"}' | jpx -s '[].name'
  # Output: ["alice", "bob"]
  ```

### Library
- **`json_pointer`**: Access values using RFC 6901 JSON Pointer syntax
  ```
  json_pointer({foo: {bar: [1,2,3]}}, '/foo/bar/1')  // 2
  json_pointer(@, '/a~1b')  // handles escaped characters
  ```

- Added `json_encode` to registry metadata (function existed but wasn't in registry)

## Closes
- Closes #30 (null input mode)
- Closes #31 (slurp mode)  
- Partially addresses #28 (json_pointer implemented; json_path deferred)