### PR TITLE
feat(jpx): add colored JSON output

### DIFF
--- a/examples/jpx/Cargo.toml
+++ b/examples/jpx/Cargo.toml
@@ -16,3 +16,5 @@ jmespath_extensions = { path = "../..", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
+colored_json = "5"
+atty = "0.2"


### PR DESCRIPTION
## Summary
Adds syntax highlighting for JSON output in jpx.

## Changes
- New `--color` flag with three modes:
  - `auto` (default): Colorize when stdout is a TTY
  - `always`: Always colorize output
  - `never`: Never colorize output

## Example
```bash
echo '{"name": "alice", "age": 30, "active": true}' | jpx '@'
```

Output shows:
- Strings in green
- Numbers in cyan  
- Booleans in yellow
- Null in red/dim
- Keys in blue

## Implementation
- Uses `colored_json` crate for syntax highlighting
- Uses `atty` crate for TTY detection
- Colors automatically disabled for compact mode (`-c`)

## Closes
- Closes #35