### PR TITLE
feat(jpx): customize color scheme for better visibility

### DIFF
--- a/examples/jpx/Cargo.toml
+++ b/examples/jpx/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 jmespath = "0.4"
 jmespath_extensions = { path = "../..", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
+serde = "1.0"
 serde_json = "1.0"
 anyhow = "1.0"
 colored_json = "5"


### PR DESCRIPTION
## Summary
Improves the color scheme for JSON output to make different value types more distinguishable.

## Color Scheme
- **Blue bold** - keys
- **Green** - strings
- **Cyan** - numbers (integer and float)
- **Yellow** - null values
- **Dim red** - booleans (true/false)

## Changes
- Uses custom `Styler` instead of default `colored_json` colors
- Added `serde` dependency for custom serialization

Follow-up to #41.