### PR TITLE
feat(jpx): add verbose mode, query chaining, and shell completions

### DIFF
--- a/examples/jpx/Cargo.toml
+++ b/examples/jpx/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 jmespath = "0.4"
 jmespath_extensions = { path = "../..", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde = "1.0"
 serde_json = "1.0"
 anyhow = "1.0"


### PR DESCRIPTION
## Summary
Adds three highly requested jpx CLI enhancements for better usability and debugging.

### New Features

#### Verbose Mode (-v/--verbose) - Closes #54
Shows detailed information about query execution:
```bash
$ echo '{"users": [{"name": "Alice"}]}' | jpx -v 'users[0].name'
Input: object (1 keys)

[1] Expression: users[0].name
[1] Result: string "Alice"
[1] Time: 0.024ms

Total time: 0.178ms

"Alice"
```

#### Query Chaining (-e/--expression) - Closes #58
Chain multiple expressions where output of one becomes input to next:
```bash
$ echo '{"users": [{"name": "Alice", "age": 30}]}' | jpx -e 'users' -e '[?age > `25`]' -e '[0].name'
"Alice"
```

#### Shell Completions (--completions) - Closes #33
Generate completions for your shell:
```bash
# Bash
jpx --completions bash > ~/.local/share/bash-completion/completions/jpx

# Zsh
jpx --completions zsh > ~/.zfunc/_jpx

# Fish
jpx --completions fish > ~/.config/fish/completions/jpx.fish
```

## Changes
- Added `clap_complete` dependency
- New Args fields: `-v/--verbose`, `-e/--expression` (repeatable), `--completions`
- Expression chaining logic with per-step timing
- `describe_value()` helper for verbose output