### PR TITLE
fix: correct rust-toolchain action name in release-plz.yml

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:


### PR DESCRIPTION
Fixes the action name from `dtolnay/rust-action` to `dtolnay/rust-toolchain`.

The previous name was incorrect and caused the workflow to fail with 'repository not found'.