### PR TITLE
fix: remove invalid allow_dirty option from release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,8 +4,6 @@ changelog_update = true
 git_tag_enable = true
 # Validate semantic versioning
 semver_check = true
-# Allow dirty working directory (cargo-dist modifies CI files)
-allow_dirty = ["ci"]
 # PR configuration
 pr_labels = ["release"]
 


### PR DESCRIPTION
The `allow_dirty` option with an array value is a cargo-dist config option, not a release-plz option. release-plz expects a boolean for `allow_dirty`, causing the workflow to fail with:

```
TOML parse error at line 8, column 15
     |
   8 | allow_dirty = ["ci"]
     |               ^^^^^^
invalid type: sequence, expected a boolean
```

This removes the invalid option.