### PR TITLE
fix: use correct [[package]] array syntax in release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,13 +8,15 @@ semver_check = true
 pr_labels = ["release"]
 
 # Main library - let cargo-dist handle GitHub releases
-[package.jmespath_extensions]
+[[package]]
+name = "jmespath_extensions"
 publish = true
 git_release_enable = false
 git_tag_name = "v{{ version }}"
 
 # CLI tool - separate versioning, let cargo-dist handle GitHub releases
-[package.jpx]
+[[package]]
+name = "jpx"
 publish = true
 git_release_enable = false
 git_tag_name = "jpx-v{{ version }}"


### PR DESCRIPTION
release-plz expects `[[package]]` with a `name` field (TOML array of tables), not `[package.name]` syntax.

Before:
```toml
[package.jmespath_extensions]
publish = true
```

After:
```toml
[[package]]
name = "jmespath_extensions"
publish = true
```