### PR TITLE
fix: correct homebrew asset URL to match cargo-dist naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,7 @@ jobs:
           formula-path: Formula/jpx.rb
           homebrew-tap: joshrotenberg/homebrew-brew
           tag-name: ${{ github.ref_name }}
-          download-url: https://github.com/joshrotenberg/jmespath-extensions/releases/download/${{ github.ref_name }}/jpx-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz
+          # cargo-dist names assets as jpx-<target>.tar.xz (no version in filename)
+          download-url: https://github.com/joshrotenberg/jmespath-extensions/releases/download/${{ github.ref_name }}/jpx-x86_64-apple-darwin.tar.xz
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
cargo-dist names assets as `jpx-<target>.tar.xz` without version prefix in the filename.

Fixes the homebrew update job that was failing with:
```
could not find asset 'jpx-v0.1.0-x86_64-apple-darwin.tar.gz' in 'jpx-v0.1.0' release
```

The actual asset name is `jpx-x86_64-apple-darwin.tar.xz`.