### PR TITLE
fix: only trigger binary release workflow for jpx tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+      # Only build binaries for jpx releases (library has no binaries)
       - "jpx-v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:


### PR DESCRIPTION
The `jmespath_extensions` library doesn't produce binaries, so cargo-dist has nothing to build for `v*.*.*` tags. 

Only `jpx-v*.*.*` tags should trigger binary builds.

This prevents the workflow from failing on library releases with:
```
This workspace doesn't have anything for dist to Release!
```

Library releases still get:
- Published to crates.io via release-plz
- Git tags created

jpx releases get:
- Published to crates.io via release-plz  
- Git tags created
- Binary builds via cargo-dist
- Homebrew formula updated