### PR TITLE
fix: enable GitHub release creation for jmespath_extensions library

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,11 +7,11 @@ semver_check = true
 # PR configuration
 pr_labels = ["release"]
 
-# Main library - let cargo-dist handle GitHub releases
+# Main library - release-plz creates GitHub release (no binaries needed)
 [[package]]
 name = "jmespath_extensions"
 publish = true
-git_release_enable = false
+git_release_enable = true
 git_tag_name = "v{{ version }}"
 
 # CLI tool - separate versioning, let cargo-dist handle GitHub releases


### PR DESCRIPTION
release-plz should create the GitHub release for the library since cargo-dist only handles jpx binary releases.

## Current flow after this fix:

**jmespath_extensions (library):**
- ✅ Published to crates.io via release-plz
- ✅ Git tag `v*.*.*` created via release-plz  
- ✅ GitHub release created via release-plz (no binaries)

**jpx (CLI):**
- ✅ Published to crates.io via release-plz
- ✅ Git tag `jpx-v*.*.*` created via release-plz
- ✅ GitHub release with binaries via cargo-dist
- ✅ Homebrew formula updated