### PR TITLE
fix: pass clean version tag to homebrew action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          # Convert jpx-v0.1.0 to v0.1.0
+          # Convert jpx-v0.1.1 to v0.1.1 for homebrew action
           VERSION="${GITHUB_REF_NAME#jpx-}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Update Homebrew formula
@@ -231,7 +231,8 @@ jobs:
           formula-name: jpx
           formula-path: Formula/jpx.rb
           homebrew-tap: joshrotenberg/homebrew-brew
-          tag-name: ${{ github.ref_name }}
+          # Use clean version (v0.1.1) not full tag (jpx-v0.1.1) for version comparison
+          tag-name: ${{ steps.version.outputs.version }}
           # cargo-dist names assets as jpx-<target>.tar.xz (no version in filename)
           download-url: https://github.com/joshrotenberg/jmespath-extensions/releases/download/${{ github.ref_name }}/jpx-x86_64-apple-darwin.tar.xz
         env:


### PR DESCRIPTION
The bump-homebrew-formula-action extracts version by stripping leading 'v' from tag names (v1.2.3 -> 1.2.3). But our jpx tags are 'jpx-v0.1.1' which doesn't match the pattern, causing the version comparison to fail with:

```
Skipping: the formula version '0.1.0' is newer than 'jpx-v0.1.1'
```

This happens because string comparison of '0.1.0' vs 'jpx-v0.1.1' considers '0' < 'j'.

This fix passes the extracted clean version (v0.1.1) instead of the full tag (jpx-v0.1.1) so the action correctly compares versions and updates the homebrew formula.