### PR TITLE
fix: compute tag in step for workflow_dispatch compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,17 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ inputs.tag || github.ref_name }}
-      tag-flag: ${{ format('--tag={0}', inputs.tag || github.ref_name) }}
+      tag: ${{ steps.get-tag.outputs.tag }}
+      tag-flag: ${{ steps.get-tag.outputs.tag-flag }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Determine tag
+        id: get-tag
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "tag-flag=--tag=$TAG" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}


### PR DESCRIPTION
The `inputs.tag` context wasn't being resolved correctly in job outputs when using `format()`. The tag was resolving to `main` instead of `jpx-v0.1.2`.

Moving tag computation to an explicit step ensures it works for both push triggers and workflow_dispatch.

After merging, retry:
```
gh workflow run release.yml -f tag=jpx-v0.1.2
```