### PR TITLE
fix: use step output for tag in dist plan command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           path: ~/.cargo/bin/dist
       - id: plan
         run: |
-          dist host --steps=create --tag=${{ github.ref_name }} --output-format=json > plan-dist-manifest.json
+          dist host --steps=create ${{ steps.get-tag.outputs.tag-flag }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The plan step was still using `github.ref_name` directly instead of the computed tag from the get-tag step. This caused workflow_dispatch to fail with `--tag=main` instead of the actual tag.

After merging, retry:
```
gh workflow run release.yml -f tag=jpx-v0.1.3
```