### PR TITLE
fix: use COMMITTER_TOKEN in release-plz to trigger Release workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,11 +22,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.COMMITTER_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use COMMITTER_TOKEN (PAT) so tag pushes trigger the Release workflow
+          # GITHUB_TOKEN actions don't trigger other workflows (security feature)
+          GITHUB_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Problem

When release-plz creates tags using `GITHUB_TOKEN`, GitHub doesn't trigger the `on: push: tags` Release workflow. This is a GitHub security feature to prevent infinite workflow loops.

## Solution

Use `COMMITTER_TOKEN` (a PAT) instead. Tags pushed with a PAT will trigger other workflows.

This is the same pattern used in redisctl which has fully automated releases.

## After merging

The next release-plz run should automatically trigger the Release workflow when it creates jpx tags - no manual `gh workflow run` needed.