### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ulid = "1.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.3.3" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.3.4" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.3...v0.3.4) - 2025-12-09
+
+### Added
+
+- add new array and string functions ([#101](https://github.com/joshrotenberg/jmespath-extensions/pull/101))
+
 ## [0.3.3](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.2...v0.3.3) - 2025-12-09
 
 ### Other

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.3...jpx-v0.1.4) - 2025-12-09
+
+### Other
+
+- updated the following local packages: jmespath_extensions
+
 ## [0.1.3](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.2...jpx-v0.1.3) - 2025-12-09
 
 ### Other

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `jpx`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.3.4](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.3...v0.3.4) - 2025-12-09

### Added

- add new array and string functions ([#101](https://github.com/joshrotenberg/jmespath-extensions/pull/101))
</blockquote>

## `jpx`

<blockquote>

## [0.1.4](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.3...jpx-v0.1.4) - 2025-12-09

### Other

- updated the following local packages: jmespath_extensions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).