### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ json-patch = "4.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.3.4" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.3.5" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.4...v0.3.5) - 2025-12-09
+
+### Added
+
+- add JSON Patch and Merge Patch functions (Issue #60) ([#108](https://github.com/joshrotenberg/jmespath-extensions/pull/108))
+- add array utility functions (Issue #62) ([#107](https://github.com/joshrotenberg/jmespath-extensions/pull/107))
+- add statistical functions (histogram, normalize, z_score, correlation) ([#104](https://github.com/joshrotenberg/jmespath-extensions/pull/104))
+
 ## [0.3.4](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.3...v0.3.4) - 2025-12-09
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.4...jpx-v0.1.5) - 2025-12-09
+
+### Other
+
+- reduce unnecessary allocations in jpx CLI ([#109](https://github.com/joshrotenberg/jmespath-extensions/pull/109))
+
 ## [0.1.4](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.3...jpx-v0.1.4) - 2025-12-09
 
 ### Other

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `jpx`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.3.5](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.4...v0.3.5) - 2025-12-09

### Added

- add JSON Patch and Merge Patch functions (Issue #60) ([#108](https://github.com/joshrotenberg/jmespath-extensions/pull/108))
- add array utility functions (Issue #62) ([#107](https://github.com/joshrotenberg/jmespath-extensions/pull/107))
- add statistical functions (histogram, normalize, z_score, correlation) ([#104](https://github.com/joshrotenberg/jmespath-extensions/pull/104))
</blockquote>

## `jpx`

<blockquote>

## [0.1.5](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.4...jpx-v0.1.5) - 2025-12-09

### Other

- reduce unnecessary allocations in jpx CLI ([#109](https://github.com/joshrotenberg/jmespath-extensions/pull/109))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).