### PR TITLE
docs: add attribution to jmespath crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 
 Extended functions for JMESPath queries in Rust. **190+ functions** for strings, arrays, dates, hashing, encoding, and more.
 
+## Built on jmespath.rs
+
+This crate extends the [`jmespath`](https://crates.io/crates/jmespath) crate by [@mtdowling](https://github.com/mtdowling), which provides the complete Rust implementation of the [JMESPath specification](https://jmespath.org/specification.html). All spec-compliant parsing, evaluation, and the 26 built-in functions come from that foundational library—we simply add extra functions on top.
+
+**If you only need standard JMESPath functionality, use [`jmespath`](https://crates.io/crates/jmespath) directly.**
+
+---
+
 **Want to try it out?** Install the `jpx` CLI tool:
 
 ```bash

--- a/jmespath_extensions/README.md
+++ b/jmespath_extensions/README.md
@@ -7,6 +7,12 @@
 
 Extended functions for JMESPath queries in Rust.
 
+## Built on jmespath.rs
+
+This crate extends the [`jmespath`](https://crates.io/crates/jmespath) crate by [@mtdowling](https://github.com/mtdowling), which provides the complete Rust implementation of the [JMESPath specification](https://jmespath.org/specification.html). All spec-compliant parsing, evaluation, and the 26 built-in functions come from that foundational library—we simply add extra functions on top.
+
+**If you only need standard JMESPath functionality, use [`jmespath`](https://crates.io/crates/jmespath) directly.**
+
 > **Non-Standard Extensions - Not Portable**
 >
 > This crate provides **custom extension functions** that are **NOT part of the [JMESPath specification](https://jmespath.org/specification.html)**.

--- a/jmespath_extensions/src/lib.rs
+++ b/jmespath_extensions/src/lib.rs
@@ -6,6 +6,16 @@
 //!
 //! A comprehensive collection of 150+ extension functions for [JMESPath](https://jmespath.org/) queries.
 //!
+//! ## Built on jmespath.rs
+//!
+//! This crate extends the [`jmespath`](https://crates.io/crates/jmespath) crate by
+//! [@mtdowling](https://github.com/mtdowling), which provides the complete Rust implementation
+//! of the [JMESPath specification](https://jmespath.org/specification.html). All spec-compliant
+//! parsing, evaluation, and the 26 built-in functions come from that foundational library—we
+//! simply add extra functions on top.
+//!
+//! **If you only need standard JMESPath functionality, use [`jmespath`](https://crates.io/crates/jmespath) directly.**
+//!
 //! ## Non-Standard Extension Warning
 //!
 //! > **These functions are NOT part of the [JMESPath specification](https://jmespath.org/specification.html).**

--- a/jpx/README.md
+++ b/jpx/README.md
@@ -4,7 +4,9 @@
 [![Downloads](https://img.shields.io/crates/d/jpx.svg)](https://crates.io/crates/jpx)
 [![License](https://img.shields.io/crates/l/jpx.svg)](https://github.com/joshrotenberg/jmespath-extensions#license)
 
-A command-line tool for querying JSON data using JMESPath expressions with 189 additional functions beyond the standard JMESPath specification. Also includes the 26 standard JMESPath built-in functions.
+A command-line tool for querying JSON data using JMESPath expressions with 190+ additional functions beyond the standard JMESPath specification.
+
+Built on the [`jmespath`](https://crates.io/crates/jmespath) crate by [@mtdowling](https://github.com/mtdowling), which provides the complete Rust implementation of the [JMESPath specification](https://jmespath.org/specification.html) including parsing, evaluation, and all 26 standard built-in functions.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Clarifies that this library builds upon the [`jmespath`](https://crates.io/crates/jmespath) crate by [@mtdowling](https://github.com/mtdowling), which provides the complete Rust implementation of the JMESPath specification.

We should be clear that:
- All spec-compliant parsing and evaluation comes from `jmespath`
- The 26 standard built-in functions come from `jmespath`
- We simply add extra functions on top of that foundation
- Users who only need standard JMESPath should use `jmespath` directly

## Changes

Added "Built on jmespath.rs" section to:
- Root README.md
- jmespath_extensions/README.md  
- jmespath_extensions/src/lib.rs (rustdoc)
- jpx/README.md