### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ json-patch = "4.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.3.5" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.3.6" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.5...v0.3.6) - 2025-12-09
+
+### Added
+
+- add lodash-inspired object path functions ([#115](https://github.com/joshrotenberg/jmespath-extensions/pull/115))
+- add count_by expression function ([#114](https://github.com/joshrotenberg/jmespath-extensions/pull/114))
+- add date/time utility functions ([#111](https://github.com/joshrotenberg/jmespath-extensions/pull/111))
+
+### Other
+
+- add attribution to jmespath crate ([#112](https://github.com/joshrotenberg/jmespath-extensions/pull/112))
+
 ## [0.3.5](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.4...v0.3.5) - 2025-12-09
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.5...jpx-v0.1.6) - 2025-12-09
+
+### Other
+
+- add attribution to jmespath crate ([#112](https://github.com/joshrotenberg/jmespath-extensions/pull/112))
+
 ## [0.1.5](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.4...jpx-v0.1.5) - 2025-12-09
 
 ### Other

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.3.5 -> 0.3.6 (✓ API compatible changes)
* `jpx`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.3.6](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.5...v0.3.6) - 2025-12-09

### Added

- add lodash-inspired object path functions ([#115](https://github.com/joshrotenberg/jmespath-extensions/pull/115))
- add count_by expression function ([#114](https://github.com/joshrotenberg/jmespath-extensions/pull/114))
- add date/time utility functions ([#111](https://github.com/joshrotenberg/jmespath-extensions/pull/111))

### Other

- add attribution to jmespath crate ([#112](https://github.com/joshrotenberg/jmespath-extensions/pull/112))
</blockquote>

## `jpx`

<blockquote>

## [0.1.6](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.5...jpx-v0.1.6) - 2025-12-09

### Other

- add attribution to jmespath crate ([#112](https://github.com/joshrotenberg/jmespath-extensions/pull/112))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).