### PR TITLE
feat: add count_by expression function

### DIFF
--- a/jmespath_extensions/src/registry.rs
+++ b/jmespath_extensions/src/registry.rs
@@ -2165,6 +2165,17 @@ fn expression_functions() -> Vec<FunctionInfo> {
             features: &[Feature::Core],
         },
         FunctionInfo {
+            name: "count_by",
+            category: Category::Expression,
+            description: "Count occurrences grouped by expression result",
+            signature: "string, array -> object",
+            example: "count_by('type', [{type: 'a'}, {type: 'b'}, {type: 'a'}]) -> {a: 2, b: 1}",
+            is_standard: false,
+            jep: None,
+            aliases: &[],
+            features: &[Feature::Core],
+        },
+        FunctionInfo {
             name: "partition_expr",
             category: Category::Expression,
             description: "Split array into [matches, non-matches] based on expression",


### PR DESCRIPTION
Closes #49

## Summary

Implements the final function from issue #49: `count_by`.

## New Function

`count_by(expr, array)` - Count occurrences of elements grouped by an expression result.

Similar to:
- `frequencies()` but with expression support for extracting the grouping key
- `group_by_expr()` but returns counts instead of grouped elements

## Examples

```
count_by('type', [{type: 'a'}, {type: 'b'}, {type: 'a'}])
// => {a: 2, b: 1}

count_by('@', ['a', 'b', 'a', 'c', 'a'])
// => {a: 3, b: 1, c: 1}
```

## Issue #49 Status

All functions from issue #49 are now implemented:
- [x] `every` (alias for `all_expr`)
- [x] `some` (alias for `any_expr`)
- [x] `find_last` 
- [x] `reject`
- [x] `order_by`
- [x] `count_by` ← this PR