### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ json-patch = "4.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.3.6" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.4.0" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.6...v0.4.0) - 2025-12-09
+
+### Added
+
+- [**breaking**] align functions with JEP-013 and JEP-014 specs ([#125](https://github.com/joshrotenberg/jmespath-extensions/pull/125))
+- add partial application functions (partial, apply) ([#124](https://github.com/joshrotenberg/jmespath-extensions/pull/124))
+
 ## [0.3.6](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.5...v0.3.6) - 2025-12-09
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.3.6"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.6...jpx-v0.1.7) - 2025-12-09
+
+### Added
+
+- *(jpx)* add --explain flag to show parsed AST ([#118](https://github.com/joshrotenberg/jmespath-extensions/pull/118))
+- *(jpx)* add cargo-style colored help output ([#116](https://github.com/joshrotenberg/jmespath-extensions/pull/116))
+
 ## [0.1.6](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.5...jpx-v0.1.6) - 2025-12-09
 
 ### Other

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.3.6 -> 0.4.0 (✓ API compatible changes)
* `jpx`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.6...v0.4.0) - 2025-12-09

### Added

- [**breaking**] align functions with JEP-013 and JEP-014 specs ([#125](https://github.com/joshrotenberg/jmespath-extensions/pull/125))
- add partial application functions (partial, apply) ([#124](https://github.com/joshrotenberg/jmespath-extensions/pull/124))
</blockquote>

## `jpx`

<blockquote>

## [0.1.7](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.6...jpx-v0.1.7) - 2025-12-09

### Added

- *(jpx)* add --explain flag to show parsed AST ([#118](https://github.com/joshrotenberg/jmespath-extensions/pull/118))
- *(jpx)* add cargo-style colored help output ([#116](https://github.com/joshrotenberg/jmespath-extensions/pull/116))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).