### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ json-patch = "4.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.4.0" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.4.1" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.4.0...v0.4.1) - 2025-12-10
+
+### Added
+
+- *(datetime)* add is_after, is_before, is_between, time_ago functions ([#126](https://github.com/joshrotenberg/jmespath-extensions/pull/126))
+
 ## [0.4.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.3.6...v0.4.0) - 2025-12-09
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.7...jpx-v0.1.8) - 2025-12-10
+
+### Other
+
+- updated the following local packages: jmespath_extensions
+
 ## [0.1.7](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.6...jpx-v0.1.7) - 2025-12-09
 
 ### Added

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `jpx`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.4.1](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.4.0...v0.4.1) - 2025-12-10

### Added

- *(datetime)* add is_after, is_before, is_between, time_ago functions ([#126](https://github.com/joshrotenberg/jmespath-extensions/pull/126))
</blockquote>

## `jpx`

<blockquote>

## [0.1.8](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.7...jpx-v0.1.8) - 2025-12-10

### Other

- updated the following local packages: jmespath_extensions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).