### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ aho-corasick = "1.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.4.1" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.5.0" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.4.1...v0.5.0) - 2025-12-10
+
+### Added
+
+- add aho-corasick multi-pattern matching functions ([#129](https://github.com/joshrotenberg/jmespath-extensions/pull/129))
+
 ## [0.4.1](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.4.0...v0.4.1) - 2025-12-10
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.8...jpx-v0.1.9) - 2025-12-10
+
+### Other
+
+- updated the following local packages: jmespath_extensions
+
 ## [0.1.8](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.7...jpx-v0.1.8) - 2025-12-10
 
 ### Other

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `jpx`: 0.1.8 -> 0.1.9

### ⚠ `jmespath_extensions` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant Category:MultiMatch in /tmp/.tmprNV2hF/jmespath-extensions/jmespath_extensions/src/registry.rs:94
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.5.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.4.1...v0.5.0) - 2025-12-10

### Added

- add aho-corasick multi-pattern matching functions ([#129](https://github.com/joshrotenberg/jmespath-extensions/pull/129))
</blockquote>

## `jpx`

<blockquote>

## [0.1.9](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.8...jpx-v0.1.9) - 2025-12-10

### Other

- updated the following local packages: jmespath_extensions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).