### PR TITLE
docs: add missing jsonpatch and multi-match to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ All features are opt-in. Use `default-features = false` to select only what you 
 | `duration` | `parse_duration`, `format_duration`, etc. | None |
 | `color` | `hex_to_rgb`, `rgb_to_hex`, `lighten`, `darken`, etc. | None |
 | `computing` | `parse_bytes`, `format_bytes`, `bit_and`, `bit_or`, etc. | None |
+| `jsonpatch` | `json_patch`, `json_merge_patch`, `json_diff` (RFC 6902/7386) | json-patch |
+| `multi-match` | `match_any`, `match_all`, `match_which`, `match_count`, `replace_many` | aho-corasick |
 
 ### Minimal Dependencies
 
@@ -251,6 +253,24 @@ geo_bearing(`40.7128`, `-74.0060`, `51.5074`, `-0.1278`)     → 51.2
 ```
 cidr_contains('192.168.0.0/16', '192.168.1.1') → true
 is_private_ip('10.0.0.1')                      → true
+```
+
+### JSON Patch (RFC 6902/7386)
+
+```
+json_patch({a: 1}, [{op: 'add', path: '/b', value: 2}])  → {a: 1, b: 2}
+json_merge_patch({a: 1}, {b: 2})                        → {a: 1, b: 2}
+json_diff({a: 1}, {a: 2})                               → [{op: 'replace', path: '/a', value: 2}]
+```
+
+### Multi-Pattern Matching (Aho-Corasick)
+
+```
+match_any('hello world', ['world', 'foo'])              → true
+match_all('hello world', ['hello', 'world'])            → true
+match_which('hello world', ['hello', 'foo', 'world'])   → ["hello", "world"]
+match_count('abcabc', ['a', 'b'])                       → 4
+replace_many('hello world', {hello: 'hi', world: 'earth'}) → "hi earth"
 ```
 
 See the [API documentation](https://docs.rs/jmespath_extensions) for complete function reference with examples.

--- a/jmespath_extensions/README.md
+++ b/jmespath_extensions/README.md
@@ -188,6 +188,8 @@ All features are opt-in. Use `default-features = false` to select only what you 
 | `duration` | `parse_duration`, `format_duration`, etc. | None |
 | `color` | `hex_to_rgb`, `rgb_to_hex`, `lighten`, `darken`, etc. | None |
 | `computing` | `parse_bytes`, `format_bytes`, `bit_and`, `bit_or`, etc. | None |
+| `jsonpatch` | `json_patch`, `json_merge_patch`, `json_diff` (RFC 6902/7386) | json-patch |
+| `multi-match` | `match_any`, `match_all`, `match_which`, `match_count`, `replace_many` | aho-corasick |
 
 ### Minimal Dependencies
 
@@ -257,6 +259,24 @@ geo_bearing(`40.7128`, `-74.0060`, `51.5074`, `-0.1278`)     → 51.2
 ```
 cidr_contains('192.168.0.0/16', '192.168.1.1') → true
 is_private_ip('10.0.0.1')                      → true
+```
+
+### JSON Patch (RFC 6902/7386)
+
+```
+json_patch({a: 1}, [{op: 'add', path: '/b', value: 2}])  → {a: 1, b: 2}
+json_merge_patch({a: 1}, {b: 2})                        → {a: 1, b: 2}
+json_diff({a: 1}, {a: 2})                               → [{op: 'replace', path: '/a', value: 2}]
+```
+
+### Multi-Pattern Matching (Aho-Corasick)
+
+```
+match_any('hello world', ['world', 'foo'])              → true
+match_all('hello world', ['hello', 'world'])            → true
+match_which('hello world', ['hello', 'foo', 'world'])   → ["hello", "world"]
+match_count('abcabc', ['a', 'b'])                       → 4
+replace_many('hello world', {hello: 'hi', world: 'earth'}) → "hi earth"
 ```
 
 See the [API documentation](https://docs.rs/jmespath_extensions) for complete function reference with examples.

--- a/jmespath_extensions/src/lib.rs
+++ b/jmespath_extensions/src/lib.rs
@@ -164,6 +164,7 @@
 //! | `color` | none | [Color manipulation](color/index.html) |
 //! | `computing` | none | [Computing utilities](computing/index.html) |
 //! | `jsonpatch` | json-patch | [JSON Patch functions](jsonpatch/index.html) |
+//! | `multi-match` | aho-corasick | [Multi-pattern matching](multi_match/index.html) |
 //!
 //! ### Using Specific Features
 //!

--- a/jmespath_extensions/src/registry.rs
+++ b/jmespath_extensions/src/registry.rs
@@ -92,6 +92,7 @@ pub enum Category {
     Color,
     Computing,
     MultiMatch,
+    Jsonpatch,
 }
 
 impl Category {
@@ -126,6 +127,7 @@ impl Category {
             Category::Color,
             Category::Computing,
             Category::MultiMatch,
+            Category::Jsonpatch,
         ]
     }
 
@@ -160,6 +162,7 @@ impl Category {
             Category::Color => "color",
             Category::Computing => "computing",
             Category::MultiMatch => "multi-match",
+            Category::Jsonpatch => "jsonpatch",
         }
     }
 
@@ -222,6 +225,8 @@ impl Category {
             Category::Computing => true,
             #[cfg(feature = "multi-match")]
             Category::MultiMatch => true,
+            #[cfg(feature = "jsonpatch")]
+            Category::Jsonpatch => true,
             #[allow(unreachable_patterns)]
             _ => false,
         }
@@ -508,6 +513,8 @@ impl FunctionRegistry {
             Category::Computing => crate::computing::register(runtime),
             #[cfg(feature = "multi-match")]
             Category::MultiMatch => crate::multi_match::register(runtime),
+            #[cfg(feature = "jsonpatch")]
+            Category::Jsonpatch => crate::jsonpatch::register(runtime),
             #[allow(unreachable_patterns)]
             _ => {}
         }
@@ -545,6 +552,7 @@ fn get_category_functions(category: Category) -> Vec<FunctionInfo> {
         Category::Color => color_functions(),
         Category::Computing => computing_functions(),
         Category::MultiMatch => multi_match_functions(),
+        Category::Jsonpatch => jsonpatch_functions(),
     }
 }
 
@@ -3520,6 +3528,44 @@ fn multi_match_functions() -> Vec<FunctionInfo> {
             description: "Replace multiple patterns simultaneously (Aho-Corasick)",
             signature: "string, object -> string",
             example: "replace_many('hello world', {hello: 'hi', world: 'earth'}) -> \"hi earth\"",
+            is_standard: false,
+            jep: None,
+            aliases: &[],
+            features: &[Feature::Core],
+        },
+    ]
+}
+
+fn jsonpatch_functions() -> Vec<FunctionInfo> {
+    vec![
+        FunctionInfo {
+            name: "json_patch",
+            category: Category::Jsonpatch,
+            description: "Apply JSON Patch (RFC 6902) operations to an object",
+            signature: "object, array -> object",
+            example: "json_patch({a: 1}, [{op: 'add', path: '/b', value: 2}]) -> {a: 1, b: 2}",
+            is_standard: false,
+            jep: None,
+            aliases: &[],
+            features: &[Feature::Core],
+        },
+        FunctionInfo {
+            name: "json_merge_patch",
+            category: Category::Jsonpatch,
+            description: "Apply JSON Merge Patch (RFC 7386) to an object",
+            signature: "object, object -> object",
+            example: "json_merge_patch({a: 1, b: 2}, {b: 3, c: 4}) -> {a: 1, b: 3, c: 4}",
+            is_standard: false,
+            jep: None,
+            aliases: &[],
+            features: &[Feature::Core],
+        },
+        FunctionInfo {
+            name: "json_diff",
+            category: Category::Jsonpatch,
+            description: "Generate JSON Patch (RFC 6902) that transforms first object into second",
+            signature: "object, object -> array",
+            example: "json_diff({a: 1}, {a: 2}) -> [{op: 'replace', path: '/a', value: 2}]",
             is_standard: false,
             jep: None,
             aliases: &[],


### PR DESCRIPTION
## Summary

Adds missing documentation for the `jsonpatch` and `multi-match` features that were not included in the README feature tables and examples.

## Changes

- Add `Jsonpatch` category to registry with function metadata for `json_patch`, `json_merge_patch`, `json_diff`
- Add `multi-match` and `jsonpatch` features to README feature tables (both root and jmespath_extensions)
- Add example sections for JSON Patch and Multi-Pattern Matching in both READMEs
- Add `multi-match` feature to lib.rs feature table (jsonpatch was already there)

## Features Now Documented

| Feature | Functions |
|---------|-----------|
| `jsonpatch` | `json_patch`, `json_merge_patch`, `json_diff` (RFC 6902/7386) |
| `multi-match` | `match_any`, `match_all`, `match_which`, `match_count`, `replace_many` |