### PR TITLE
feat: add ngrams, bigrams, trigrams text functions

### DIFF
--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -1,5 +1,5 @@
 # JMESPath Extensions Function Registry
-# 
+#
 # This file is the single source of truth for:
 # - Function metadata (name, signature, description)
 # - Rustdoc generation (via build.rs)
@@ -2437,6 +2437,30 @@ signature = "string -> object"
 example = "word_frequencies('a a b') -> {a: 2, b: 1}"
 features = ["core"]
 
+[[functions]]
+name = "ngrams"
+category = "text"
+description = "Generate n-grams from text (word or character)"
+signature = "string, number, string? -> array"
+example = "ngrams('hello', `3`, 'char') -> \\['hel', 'ell', 'llo'\\]"
+features = ["core"]
+
+[[functions]]
+name = "bigrams"
+category = "text"
+description = "Generate word bigrams (2-grams)"
+signature = "string -> array"
+example = "bigrams('a b c') -> \\[\\['a', 'b'\\], \\['b', 'c'\\]\\]"
+features = ["core"]
+
+[[functions]]
+name = "trigrams"
+category = "text"
+description = "Generate word trigrams (3-grams)"
+signature = "string -> array"
+example = "trigrams('a b c d') -> \\[\\['a', 'b', 'c'\\], \\['b', 'c', 'd'\\]\\]"
+features = ["core"]
+
 # =============================================================================
 # TYPE FUNCTIONS
 # =============================================================================
@@ -2728,4 +2752,3 @@ description = "Generic Luhn algorithm check"
 signature = "string -> boolean"
 example = "luhn_check('79927398713') -> true"
 features = ["core"]
-


### PR DESCRIPTION
## Summary

Add n-gram generation functions to the text module - pure implementations with no external dependencies.

## New Functions

| Function | Signature | Description |
|----------|-----------|-------------|
| `ngrams` | `(string, number, string?) -> array` | Generate n-grams from text (word or char) |
| `bigrams` | `(string) -> array` | Convenience function for word 2-grams |
| `trigrams` | `(string) -> array` | Convenience function for word 3-grams |

## Examples

```
ngrams('hello', `3`, 'char')     -> ["hel", "ell", "llo"]
ngrams('the quick brown', `2`)  -> [["the", "quick"], ["quick", "brown"]]
bigrams('a b c d')               -> [["a", "b"], ["b", "c"], ["c", "d"]]
trigrams('a b c d')              -> [["a", "b", "c"], ["b", "c", "d"]]
```

## Use Cases

- Text analysis and NLP preprocessing
- Search indexing
- Similarity detection
- Language modeling features

Partial implementation of #130 (n-grams only, as discussed).