### PR TITLE
chore: add jsonpatch and multi-match to CI and benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
           - duration
           - color
           - computing
+          - jsonpatch
+          - multi-match
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Update CI and benchmarks to include the newer features added since v0.6.0.

## Changes

### CI
- Add `jsonpatch` and `multi-match` to the feature matrix test

### Benchmarks
- Add multi-match benchmarks: `match_any`, `match_all`, `match_which`, `match_count`
- Add jsonpatch benchmarks: `json_patch`, `json_merge_patch`, `json_diff`

This ensures all feature flags are tested in CI and have benchmark coverage.