### PR TITLE
fix: point readme to root README.md for crates.io publishing

### DIFF
--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -6,9 +6,9 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "Extended functions for JMESPath queries - 150+ functions for strings, arrays, dates, hashing, encoding, geo, and more"
+description = "Extended functions for JMESPath queries - 320+ functions for strings, arrays, dates, hashing, encoding, geo, and more"
 documentation = "https://docs.rs/jmespath_extensions"
-readme = "README.md"
+readme = "../README.md"
 keywords = ["jmespath", "json", "query", "transform", "filter"]
 categories = ["data-structures", "parsing", "text-processing"]
 


### PR DESCRIPTION
Fixes the release-plz failure - we deleted jmespath_extensions/README.md in PR #153 but forgot to update Cargo.toml.

Also updates the description from '150+' to '320+' functions.