### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 # Note: criterion 0.7 has breaking changes, staying on 0.5 for now
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.6.1" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.6.2" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.1...v0.6.2) - 2025-12-13
+
+### Fixed
+
+- add missing chrono and base64 deps to validation feature ([#157](https://github.com/joshrotenberg/jmespath-extensions/pull/157))
+
 ## [0.6.1](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.0...v0.6.1) - 2025-12-13
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.11...jpx-v0.1.12) - 2025-12-13
+
+### Other
+
+- updated the following local packages: jmespath_extensions
+
 ## [0.1.11](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.10...jpx-v0.1.11) - 2025-12-13
 
 ### Added

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `jpx`: 0.1.11 -> 0.1.12

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.6.2](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.1...v0.6.2) - 2025-12-13

### Fixed

- add missing chrono and base64 deps to validation feature ([#157](https://github.com/joshrotenberg/jmespath-extensions/pull/157))
</blockquote>

## `jpx`

<blockquote>

## [0.1.12](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.11...jpx-v0.1.12) - 2025-12-13

### Other

- updated the following local packages: jmespath_extensions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).