### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "jmespath_extensions"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.6.2" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.6.3" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.2...v0.6.3) - 2025-12-14
+
+### Fixed
+
+- wrap JSON literals in backticks for jsonpatch benchmarks ([#166](https://github.com/joshrotenberg/jmespath-extensions/pull/166))
+
+### Other
+
+- add quick reference table and multiple examples support ([#165](https://github.com/joshrotenberg/jmespath-extensions/pull/165))
+
 ## [0.6.2](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.1...v0.6.2) - 2025-12-13
 
 ### Fixed

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.6.2"
+version = "0.6.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.12...jpx-v0.1.13) - 2025-12-14
+
+### Added
+
+- add .suggest command for smart query suggestions ([#161](https://github.com/joshrotenberg/jmespath-extensions/pull/161))
+- add interactive REPL with syntax highlighting and demos ([#159](https://github.com/joshrotenberg/jmespath-extensions/pull/159))
+
 ## [0.1.12](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.11...jpx-v0.1.12) - 2025-12-13
 
 ### Other

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.12"
+version = "0.1.13"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `jpx`: 0.1.12 -> 0.1.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.6.3](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.2...v0.6.3) - 2025-12-14

### Fixed

- wrap JSON literals in backticks for jsonpatch benchmarks ([#166](https://github.com/joshrotenberg/jmespath-extensions/pull/166))

### Other

- add quick reference table and multiple examples support ([#165](https://github.com/joshrotenberg/jmespath-extensions/pull/165))
</blockquote>

## `jpx`

<blockquote>

## [0.1.13](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.12...jpx-v0.1.13) - 2025-12-14

### Added

- add .suggest command for smart query suggestions ([#161](https://github.com/joshrotenberg/jmespath-extensions/pull/161))
- add interactive REPL with syntax highlighting and demos ([#159](https://github.com/joshrotenberg/jmespath-extensions/pull/159))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).