### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "jmespath_extensions"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.6.3" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.7.0" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.3...v0.7.0) - 2025-12-18
+
+### Added
+
+- add jq-inspired utility functions (pretty, html_escape, env) ([#175](https://github.com/joshrotenberg/jmespath-extensions/pull/175))
+- add CSV/TSV formatting functions ([#174](https://github.com/joshrotenberg/jmespath-extensions/pull/174))
+
+### Other
+
+- update JSON Merge Patch RFC reference from 7386 to 7396 ([#170](https://github.com/joshrotenberg/jmespath-extensions/pull/170))
+
 ## [0.6.3](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.2...v0.6.3) - 2025-12-14
 
 ### Fixed

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.6.3"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.13...jpx-v0.1.14) - 2025-12-18
+
+### Added
+
+- move REPL demos to demos.toml with build.rs generation ([#168](https://github.com/joshrotenberg/jmespath-extensions/pull/168))
+
 ## [0.1.13](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.12...jpx-v0.1.13) - 2025-12-14
 
 ### Added

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.13"
+version = "0.1.14"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.6.3 -> 0.7.0 (⚠ API breaking changes)
* `jpx`: 0.1.13 -> 0.1.14

### ⚠ `jmespath_extensions` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant Category:Format in /tmp/.tmpexra3O/jmespath-extensions/jmespath_extensions/src/registry.rs:96
  variant Feature:format in /tmp/.tmpexra3O/jmespath-extensions/jmespath_extensions/src/registry.rs:254
  variant Feature:env in /tmp/.tmpexra3O/jmespath-extensions/jmespath_extensions/src/registry.rs:257
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.7.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.3...v0.7.0) - 2025-12-18

### Added

- add jq-inspired utility functions (pretty, html_escape, env) ([#175](https://github.com/joshrotenberg/jmespath-extensions/pull/175))
- add CSV/TSV formatting functions ([#174](https://github.com/joshrotenberg/jmespath-extensions/pull/174))

### Other

- update JSON Merge Patch RFC reference from 7386 to 7396 ([#170](https://github.com/joshrotenberg/jmespath-extensions/pull/170))
</blockquote>

## `jpx`

<blockquote>

## [0.1.14](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.13...jpx-v0.1.14) - 2025-12-18

### Added

- move REPL demos to demos.toml with build.rs generation ([#168](https://github.com/joshrotenberg/jmespath-extensions/pull/168))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).