### PR TITLE
docs: update JSON Merge Patch RFC reference from 7386 to 7396

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ All features are opt-in. Use `default-features = false` to select only what you 
 | `duration` | `parse_duration`, `format_duration`, etc. | None |
 | `color` | `hex_to_rgb`, `rgb_to_hex`, `lighten`, `darken`, etc. | None |
 | `computing` | `parse_bytes`, `format_bytes`, `bit_and`, `bit_or`, etc. | None |
-| `jsonpatch` | `json_patch`, `json_merge_patch`, `json_diff` (RFC 6902/7386) | json-patch |
+| `jsonpatch` | `json_patch`, `json_merge_patch`, `json_diff` (RFC 6902/7396) | json-patch |
 | `multi-match` | `match_any`, `match_all`, `match_which`, `match_count`, `replace_many` | aho-corasick |
 
 ### Minimal Dependencies
@@ -255,7 +255,7 @@ cidr_contains('192.168.0.0/16', '192.168.1.1') → true
 is_private_ip('10.0.0.1')                      → true
 ```
 
-### JSON Patch (RFC 6902/7386)
+### JSON Patch (RFC 6902/7396)
 
 ```
 json_patch({a: 1}, [{op: 'add', path: '/b', value: 2}])  → {a: 1, b: 2}

--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -1632,7 +1632,7 @@ features = ["core"]
 [[functions]]
 name = "json_merge_patch"
 category = "jsonpatch"
-description = "Apply JSON Merge Patch (RFC 7386) to an object"
+description = "Apply JSON Merge Patch (RFC 7396) to an object"
 signature = "object, object -> object"
 examples = [
     { code = "json_merge_patch({a: 1, b: 2}, {b: 3, c: 4}) -> {a: 1, b: 3, c: 4}", description = "Merge objects" },

--- a/jmespath_extensions/src/jsonpatch.rs
+++ b/jmespath_extensions/src/jsonpatch.rs
@@ -95,9 +95,9 @@ impl Function for JsonPatchFn {
 }
 
 // =============================================================================
-// json_merge_patch(obj, patch) -> object (RFC 7386)
-// Apply a JSON Merge Patch (RFC 7386) to an object.
-// See: https://datatracker.ietf.org/doc/html/rfc7386
+// json_merge_patch(obj, patch) -> object (RFC 7396)
+// Apply a JSON Merge Patch (RFC 7396) to an object.
+// See: https://datatracker.ietf.org/doc/html/rfc7396
 // =============================================================================
 
 define_function!(

--- a/jmespath_extensions/src/lib.rs
+++ b/jmespath_extensions/src/lib.rs
@@ -207,7 +207,7 @@
 //! - [`duration`] - Duration parsing (`parse_duration`, `format_duration`)
 //! - [`color`] - Color manipulation (`hex_to_rgb`, `rgb_to_hex`, `lighten`, `darken`, `color_mix`)
 //! - [`computing`] - Computing utilities (`parse_bytes`, `format_bytes`, `bit_and`, `bit_or`, `bit_xor`)
-//! - [`jsonpatch`] - JSON Patch (RFC 6902) and Merge Patch (RFC 7386) (`json_patch`, `json_merge_patch`, `json_diff`)
+//! - [`jsonpatch`] - JSON Patch (RFC 6902) and Merge Patch (RFC 7396) (`json_patch`, `json_merge_patch`, `json_diff`)
 //!
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/quick_reference.md"))]
 //!


### PR DESCRIPTION
RFC 7396 obsoletes RFC 7386. Both define the same JSON Merge Patch format, but 7396 is the current specification.

Updated references in:
- `functions.toml`
- `README.md`
- `src/lib.rs`
- `src/jsonpatch.rs`