### PR TITLE
feat: add CSV/TSV formatting functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,7 +436,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -483,7 +504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -769,7 +790,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -814,6 +835,7 @@ dependencies = [
  "chrono-tz",
  "crc32fast",
  "criterion",
+ "csv",
  "geoutils",
  "hex",
  "hmac",
@@ -1270,7 +1292,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1758,7 +1780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ nanoid = "0.4"
 ulid = "1.1"
 json-patch = "4.0"
 aho-corasick = "1.1"
+csv = "1.3"
 
 # Dev dependencies
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -40,10 +40,11 @@ nanoid = { workspace = true, optional = true }
 ulid = { workspace = true, optional = true }
 json-patch = { workspace = true, optional = true }
 aho-corasick = { workspace = true, optional = true }
+csv = { workspace = true, optional = true }
 
 [features]
 default = ["full"]
-full = ["string", "array", "object", "math", "type", "utility", "validation", "path", "hash", "encoding", "regex", "url", "uuid", "rand", "datetime", "fuzzy", "expression", "phonetic", "geo", "semver", "network", "ids", "text", "duration", "color", "computing", "jsonpatch", "multi-match"]
+full = ["string", "array", "object", "math", "type", "utility", "validation", "path", "hash", "encoding", "regex", "url", "uuid", "rand", "datetime", "fuzzy", "expression", "phonetic", "geo", "semver", "network", "ids", "text", "duration", "color", "computing", "jsonpatch", "multi-match", "format"]
 core = ["string", "array", "object", "math", "type", "utility", "validation", "path", "expression"]
 string = []
 array = []
@@ -73,6 +74,7 @@ color = []
 computing = []
 jsonpatch = ["dep:json-patch"]
 multi-match = ["dep:aho-corasick"]
+format = ["dep:csv"]
 
 [build-dependencies]
 toml = "0.8"

--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -4159,3 +4159,56 @@ examples = [
     { code = "luhn_check('0') -> true", description = "Single zero" },
 ]
 features = ["core"]
+
+# =============================================================================
+# FORMAT FUNCTIONS
+# =============================================================================
+
+[[functions]]
+name = "to_csv"
+category = "format"
+description = "Convert array to CSV row string (RFC 4180 compliant)"
+signature = "array -> string"
+examples = [
+    { code = '''to_csv(['a', 'b', 'c']) -> "a,b,c"''', description = "Simple strings" },
+    { code = '''to_csv(['hello', `42`, `true`, `null`]) -> "hello,42,true,"''', description = "Mixed types" },
+    { code = '''to_csv(['hello, world', 'test']) -> "\"hello, world\",test"''', description = "Value with comma is quoted" },
+    { code = '''to_csv(['say "hello"', 'test']) -> "\"say \"\"hello\"\"\",test"''', description = "Quotes are doubled" },
+]
+features = ["format"]
+
+[[functions]]
+name = "to_tsv"
+category = "format"
+description = "Convert array to TSV row string (tab-separated)"
+signature = "array -> string"
+examples = [
+    { code = '''to_tsv(['a', 'b', 'c']) -> "a\tb\tc"''', description = "Simple strings" },
+    { code = '''to_tsv(['hello', `42`, `true`]) -> "hello\t42\ttrue"''', description = "Mixed types" },
+]
+features = ["format"]
+
+[[functions]]
+name = "to_csv_rows"
+category = "format"
+description = "Convert array of arrays to multi-line CSV string"
+signature = "array -> string"
+examples = [
+    { code = '''to_csv_rows([[`1`, `2`, `3`], [`4`, `5`, `6`]]) -> "1,2,3\n4,5,6"''', description = "Numeric rows" },
+    { code = '''to_csv_rows([['a', 'b'], ['c', 'd']]) -> "a,b\nc,d"''', description = "String rows" },
+    { code = '''to_csv_rows([]) -> ""''', description = "Empty array" },
+]
+features = ["format"]
+
+[[functions]]
+name = "to_csv_table"
+category = "format"
+description = "Convert array of objects to CSV with header row"
+signature = "array, array? -> string"
+examples = [
+    { code = '''to_csv_table([{name: 'alice', age: `30`}]) -> "age,name\n30,alice"''', description = "Keys sorted alphabetically" },
+    { code = '''to_csv_table([{name: 'alice', age: `30`}], ['name', 'age']) -> "name,age\nalice,30"''', description = "Explicit column order" },
+    { code = '''to_csv_table([{a: `1`}, {a: `2`, b: `3`}], ['a', 'b']) -> "a,b\n1,\n2,3"''', description = "Missing fields become empty" },
+    { code = '''to_csv_table([]) -> ""''', description = "Empty array" },
+]
+features = ["format"]

--- a/jmespath_extensions/src/format.rs
+++ b/jmespath_extensions/src/format.rs
@@ -1,0 +1,485 @@
+//! CSV and TSV formatting functions.
+//!
+//! This module provides functions for formatting data as CSV/TSV strings,
+//! similar to jq's `@csv` and `@tsv` formatters.
+//!
+//! Uses the [`csv`](https://docs.rs/csv) crate for RFC 4180 compliant output.
+//!
+//! # Example
+//!
+//! ```rust
+//! use jmespath::{Runtime, Variable};
+//! use jmespath_extensions::format;
+//!
+//! let mut runtime = Runtime::new();
+//! runtime.register_builtin_functions();
+//! format::register(&mut runtime);
+//! ```
+
+use std::rc::Rc;
+
+use csv::WriterBuilder;
+
+use crate::common::{ArgumentType, Context, Function, JmespathError, Rcvar, Runtime, Variable};
+use crate::define_function;
+
+/// Register all format functions with the runtime.
+pub fn register(runtime: &mut Runtime) {
+    runtime.register_function("to_csv", Box::new(ToCsvFn::new()));
+    runtime.register_function("to_tsv", Box::new(ToTsvFn::new()));
+    runtime.register_function("to_csv_rows", Box::new(ToCsvRowsFn::new()));
+    runtime.register_function("to_csv_table", Box::new(ToCsvTableFn::new()));
+}
+
+/// Convert a JMESPath Variable to a string suitable for CSV field.
+fn variable_to_csv_string(value: &Variable) -> String {
+    match value {
+        Variable::Null => String::new(),
+        Variable::Bool(b) => b.to_string(),
+        Variable::Number(n) => n.to_string(),
+        Variable::String(s) => s.clone(),
+        Variable::Array(_) | Variable::Object(_) => {
+            // For complex types, serialize as JSON
+            serde_json::to_string(value).unwrap_or_default()
+        }
+        Variable::Expref(_) => String::new(),
+    }
+}
+
+/// Write a single row using the csv crate's writer.
+fn write_csv_row(fields: &[String], delimiter: u8) -> Result<String, std::io::Error> {
+    let mut wtr = WriterBuilder::new()
+        .delimiter(delimiter)
+        .has_headers(false)
+        .from_writer(vec![]);
+
+    wtr.write_record(fields)?;
+    wtr.flush()?;
+
+    let data = wtr
+        .into_inner()
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    // Remove trailing newline that csv crate adds
+    let mut s = String::from_utf8(data).unwrap_or_default();
+    if s.ends_with('\n') {
+        s.pop();
+    }
+    if s.ends_with('\r') {
+        s.pop();
+    }
+    Ok(s)
+}
+
+/// Write multiple rows using the csv crate's writer.
+fn write_csv_rows(rows: &[Vec<String>], delimiter: u8) -> Result<String, std::io::Error> {
+    let mut wtr = WriterBuilder::new()
+        .delimiter(delimiter)
+        .has_headers(false)
+        .from_writer(vec![]);
+
+    for row in rows {
+        wtr.write_record(row)?;
+    }
+    wtr.flush()?;
+
+    let data = wtr
+        .into_inner()
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    // Remove trailing newline
+    let mut s = String::from_utf8(data).unwrap_or_default();
+    if s.ends_with('\n') {
+        s.pop();
+    }
+    if s.ends_with('\r') {
+        s.pop();
+    }
+    Ok(s)
+}
+
+// =============================================================================
+// to_csv(array) -> string
+// =============================================================================
+
+define_function!(ToCsvFn, vec![ArgumentType::Array], None);
+
+impl Function for ToCsvFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let arr = args[0].as_array().unwrap();
+
+        // Empty array returns empty string (matches jq @csv behavior)
+        if arr.is_empty() {
+            return Ok(Rc::new(Variable::String(String::new())));
+        }
+
+        let fields: Vec<String> = arr.iter().map(|v| variable_to_csv_string(v)).collect();
+
+        match write_csv_row(&fields, b',') {
+            Ok(s) => Ok(Rc::new(Variable::String(s))),
+            Err(e) => Err(crate::common::custom_error(
+                ctx,
+                &format!("CSV write error: {}", e),
+            )),
+        }
+    }
+}
+
+// =============================================================================
+// to_tsv(array) -> string
+// =============================================================================
+
+define_function!(ToTsvFn, vec![ArgumentType::Array], None);
+
+impl Function for ToTsvFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let arr = args[0].as_array().unwrap();
+
+        // Empty array returns empty string (matches jq @tsv behavior)
+        if arr.is_empty() {
+            return Ok(Rc::new(Variable::String(String::new())));
+        }
+
+        let fields: Vec<String> = arr.iter().map(|v| variable_to_csv_string(v)).collect();
+
+        match write_csv_row(&fields, b'\t') {
+            Ok(s) => Ok(Rc::new(Variable::String(s))),
+            Err(e) => Err(crate::common::custom_error(
+                ctx,
+                &format!("TSV write error: {}", e),
+            )),
+        }
+    }
+}
+
+// =============================================================================
+// to_csv_rows(array_of_arrays) -> string
+// =============================================================================
+
+define_function!(ToCsvRowsFn, vec![ArgumentType::Array], None);
+
+impl Function for ToCsvRowsFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let rows_var = args[0].as_array().unwrap();
+
+        if rows_var.is_empty() {
+            return Ok(Rc::new(Variable::String(String::new())));
+        }
+
+        let rows: Vec<Vec<String>> = rows_var
+            .iter()
+            .map(|row| {
+                if let Some(arr) = row.as_array() {
+                    arr.iter().map(|v| variable_to_csv_string(v)).collect()
+                } else {
+                    // Single value becomes a single-column row
+                    vec![variable_to_csv_string(row)]
+                }
+            })
+            .collect();
+
+        match write_csv_rows(&rows, b',') {
+            Ok(s) => Ok(Rc::new(Variable::String(s))),
+            Err(e) => Err(crate::common::custom_error(
+                ctx,
+                &format!("CSV write error: {}", e),
+            )),
+        }
+    }
+}
+
+// =============================================================================
+// to_csv_table(array_of_objects, columns?) -> string
+// =============================================================================
+
+define_function!(
+    ToCsvTableFn,
+    vec![ArgumentType::Array],
+    Some(ArgumentType::Array)
+);
+
+impl Function for ToCsvTableFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let rows = args[0].as_array().unwrap();
+
+        if rows.is_empty() {
+            return Ok(Rc::new(Variable::String(String::new())));
+        }
+
+        // Determine columns: from second argument or from first object's keys
+        let columns: Vec<String> = if args.len() > 1 {
+            // Explicit columns provided
+            args[1]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|v| v.as_string().map(|s| s.to_string()))
+                .collect()
+        } else {
+            // Infer from first object
+            if let Some(obj) = rows[0].as_object() {
+                let mut keys: Vec<String> = obj.keys().cloned().collect();
+                keys.sort(); // Consistent ordering
+                keys
+            } else {
+                return Ok(Rc::new(Variable::String(String::new())));
+            }
+        };
+
+        if columns.is_empty() {
+            return Ok(Rc::new(Variable::String(String::new())));
+        }
+
+        // Build all rows (header + data)
+        let mut all_rows: Vec<Vec<String>> = Vec::with_capacity(rows.len() + 1);
+
+        // Header row
+        all_rows.push(columns.clone());
+
+        // Data rows
+        for row in rows.iter() {
+            if let Some(obj) = row.as_object() {
+                let data_row: Vec<String> = columns
+                    .iter()
+                    .map(|col| {
+                        obj.get(col)
+                            .map(|v| variable_to_csv_string(v))
+                            .unwrap_or_default()
+                    })
+                    .collect();
+                all_rows.push(data_row);
+            } else {
+                // Non-object row - empty values
+                all_rows.push(columns.iter().map(|_| String::new()).collect());
+            }
+        }
+
+        match write_csv_rows(&all_rows, b',') {
+            Ok(s) => Ok(Rc::new(Variable::String(s))),
+            Err(e) => Err(crate::common::custom_error(
+                ctx,
+                &format!("CSV write error: {}", e),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jmespath::Runtime;
+
+    fn setup_runtime() -> Runtime {
+        let mut runtime = Runtime::new();
+        runtime.register_builtin_functions();
+        register(&mut runtime);
+        runtime
+    }
+
+    // =========================================================================
+    // to_csv tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_csv_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = Variable::from_json(r#"["a", "b", "c"]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "a,b,c");
+    }
+
+    #[test]
+    fn test_to_csv_mixed_types() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = Variable::from_json(r#"["hello", 42, true, null]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "hello,42,true,");
+    }
+
+    #[test]
+    fn test_to_csv_with_comma() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = Variable::from_json(r#"["hello, world", "test"]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "\"hello, world\",test");
+    }
+
+    #[test]
+    fn test_to_csv_with_quotes() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = Variable::from_json(r#"["say \"hello\"", "test"]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "\"say \"\"hello\"\"\",test");
+    }
+
+    #[test]
+    fn test_to_csv_with_newline() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = Variable::from_json(r#"["line1\nline2", "test"]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "\"line1\nline2\",test");
+    }
+
+    #[test]
+    fn test_to_csv_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = Variable::from_json(r#"[]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "");
+    }
+
+    #[test]
+    fn test_to_csv_with_leading_trailing_space() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = Variable::from_json(r#"["  hello  ", "test"]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        // csv crate quotes fields with leading/trailing whitespace to preserve them
+        assert!(result.as_string().unwrap().contains("hello"));
+    }
+
+    // =========================================================================
+    // to_tsv tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_tsv_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_tsv(@)").unwrap();
+        let data = Variable::from_json(r#"["a", "b", "c"]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "a\tb\tc");
+    }
+
+    #[test]
+    fn test_to_tsv_mixed_types() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_tsv(@)").unwrap();
+        let data = Variable::from_json(r#"["hello", 42, true, null]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "hello\t42\ttrue\t");
+    }
+
+    // =========================================================================
+    // to_csv_rows tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_csv_rows_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let data = Variable::from_json(r#"[[1, 2, 3], [4, 5, 6]]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "1,2,3\n4,5,6");
+    }
+
+    #[test]
+    fn test_to_csv_rows_with_strings() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let data = Variable::from_json(r#"[["a", "b"], ["c", "d"]]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "a,b\nc,d");
+    }
+
+    #[test]
+    fn test_to_csv_rows_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let data = Variable::from_json(r#"[]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "");
+    }
+
+    #[test]
+    fn test_to_csv_rows_with_special_chars() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let data = Variable::from_json(r#"[["hello, world", "test"], ["a\"b", "c"]]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        // Should properly escape commas and quotes
+        assert!(result.as_string().unwrap().contains("\"hello, world\""));
+        assert!(result.as_string().unwrap().contains("\"a\"\"b\""));
+    }
+
+    // =========================================================================
+    // to_csv_table tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_csv_table_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_table(@)").unwrap();
+        let data =
+            Variable::from_json(r#"[{"name": "alice", "age": 30}, {"name": "bob", "age": 25}]"#)
+                .unwrap();
+        let result = expr.search(&data).unwrap();
+        // Keys are sorted alphabetically
+        assert_eq!(result.as_string().unwrap(), "age,name\n30,alice\n25,bob");
+    }
+
+    #[test]
+    fn test_to_csv_table_with_columns() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("to_csv_table(@, `[\"name\", \"age\"]`)")
+            .unwrap();
+        let data =
+            Variable::from_json(r#"[{"name": "alice", "age": 30}, {"name": "bob", "age": 25}]"#)
+                .unwrap();
+        let result = expr.search(&data).unwrap();
+        // Columns in specified order
+        assert_eq!(result.as_string().unwrap(), "name,age\nalice,30\nbob,25");
+    }
+
+    #[test]
+    fn test_to_csv_table_missing_field() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("to_csv_table(@, `[\"name\", \"age\", \"email\"]`)")
+            .unwrap();
+        let data =
+            Variable::from_json(r#"[{"name": "alice", "age": 30}, {"name": "bob"}]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        // Missing fields are empty
+        assert_eq!(
+            result.as_string().unwrap(),
+            "name,age,email\nalice,30,\nbob,,"
+        );
+    }
+
+    #[test]
+    fn test_to_csv_table_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_table(@)").unwrap();
+        let data = Variable::from_json(r#"[]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "");
+    }
+
+    #[test]
+    fn test_to_csv_table_special_chars() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_table(@)").unwrap();
+        let data =
+            Variable::from_json(r#"[{"name": "O'Brien, Jr.", "note": "said \"hi\""}]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        // Should properly escape commas and quotes
+        assert!(result.as_string().unwrap().contains("\"O'Brien, Jr.\""));
+        assert!(result.as_string().unwrap().contains("\"said \"\"hi\"\"\""));
+    }
+}

--- a/jmespath_extensions/src/lib.rs
+++ b/jmespath_extensions/src/lib.rs
@@ -344,6 +344,9 @@ pub mod jsonpatch;
 #[cfg(feature = "multi-match")]
 pub mod multi_match;
 
+#[cfg(feature = "format")]
+pub mod format;
+
 /// Register all available extension functions with a JMESPath runtime.
 ///
 /// This function registers all functions enabled by the current feature flags.
@@ -456,6 +459,9 @@ pub fn register_all(runtime: &mut Runtime) {
 
     #[cfg(feature = "multi-match")]
     multi_match::register(runtime);
+
+    #[cfg(feature = "format")]
+    format::register(runtime);
 }
 
 #[cfg(test)]

--- a/jmespath_extensions/src/registry.rs
+++ b/jmespath_extensions/src/registry.rs
@@ -93,6 +93,7 @@ pub enum Category {
     Computing,
     MultiMatch,
     Jsonpatch,
+    Format,
 }
 
 impl Category {
@@ -128,6 +129,7 @@ impl Category {
             Category::Computing,
             Category::MultiMatch,
             Category::Jsonpatch,
+            Category::Format,
         ]
     }
 
@@ -163,6 +165,7 @@ impl Category {
             Category::Computing => "computing",
             Category::MultiMatch => "multi-match",
             Category::Jsonpatch => "jsonpatch",
+            Category::Format => "format",
         }
     }
 
@@ -227,6 +230,8 @@ impl Category {
             Category::MultiMatch => true,
             #[cfg(feature = "jsonpatch")]
             Category::Jsonpatch => true,
+            #[cfg(feature = "format")]
+            Category::Format => true,
             #[allow(unreachable_patterns)]
             _ => false,
         }
@@ -244,12 +249,21 @@ pub enum Feature {
     Fp,
     /// JEP-aligned functions
     Jep,
+    /// Format output functions (CSV, TSV)
+    #[allow(non_camel_case_types)]
+    format,
 }
 
 impl Feature {
     /// Returns all features
     pub fn all() -> &'static [Feature] {
-        &[Feature::Spec, Feature::Core, Feature::Fp, Feature::Jep]
+        &[
+            Feature::Spec,
+            Feature::Core,
+            Feature::Fp,
+            Feature::Jep,
+            Feature::format,
+        ]
     }
 
     /// Returns the feature name as a string
@@ -259,6 +273,7 @@ impl Feature {
             Feature::Core => "core",
             Feature::Fp => "fp",
             Feature::Jep => "jep",
+            Feature::format => "format",
         }
     }
 }
@@ -515,6 +530,8 @@ impl FunctionRegistry {
             Category::MultiMatch => crate::multi_match::register(runtime),
             #[cfg(feature = "jsonpatch")]
             Category::Jsonpatch => crate::jsonpatch::register(runtime),
+            #[cfg(feature = "format")]
+            Category::Format => crate::format::register(runtime),
             #[allow(unreachable_patterns)]
             _ => {}
         }


### PR DESCRIPTION
## Summary
Implements issue #172 - CSV/TSV output formatting functions.

## New Functions
- `to_csv(array)` - Convert array to CSV row
- `to_tsv(array)` - Convert array to TSV row  
- `to_csv_rows(array_of_arrays)` - Convert arrays to multi-line CSV
- `to_csv_table(array_of_objects, columns?)` - Convert objects to CSV table with headers

## Implementation Details
- Uses the `csv` crate for RFC 4180 compliant output
- Proper handling of edge cases: commas, quotes, newlines, whitespace
- Available via the `format` feature flag
- 18 unit tests covering all edge cases

## Example Usage
```
# Simple array to CSV
jpx '["a", "b", "c"] | to_csv(@)'
# Output: a,b,c

# Handle special characters
jpx '["hello, world", "say \"hi\""] | to_csv(@)'
# Output: "hello, world","say ""hi"""

# Objects to table
jpx '[{"name": "alice", "age": 30}, {"name": "bob", "age": 25}] | to_csv_table(@, [`name`, `age`])'
# Output:
# name,age
# alice,30
# bob,25
```

Closes #172