### PR TITLE
docs: highlight MCP server in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@
 
 Extended functions for JMESPath queries in Rust. **320+ functions** for strings, arrays, dates, hashing, encoding, and more.
 
+## MCP Server for AI Assistants
+
+Use jpx as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server to give AI assistants like Claude the ability to query and transform JSON data.
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "jpx",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+**12 tools available:** `evaluate`, `evaluate_file`, `batch_evaluate`, `functions`, `describe`, `categories`, `validate`, `format`, `diff`, `patch`, `merge`, `keys`
+
+See [jpx MCP documentation](jpx/MCP.md) for details.
+
+---
+
 ## Built on jmespath.rs
 
 This crate extends the [`jmespath`](https://crates.io/crates/jmespath) crate by [@mtdowling](https://github.com/mtdowling), which provides the complete Rust implementation of the [JMESPath specification](https://jmespath.org/specification.html). All spec-compliant parsing, evaluation, and the 26 built-in functions come from that foundational library—we simply add extra functions on top.


### PR DESCRIPTION
Adds a prominent MCP Server section near the top of the main README to improve discoverability.

This makes it easier for users landing on the repo to see that jpx can be used as an MCP server for AI assistants like Claude.

- Adds config example for Claude/Cursor
- Lists all 12 available tools
- Links to detailed MCP documentation