### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "jmespath_extensions"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.7.0" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.8.0" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.7.0...v0.8.0) - 2026-01-14
+
+### Added
+
+- *(discovery)* add fuzzy_search, fuzzy_match, and fuzzy_score functions ([#288](https://github.com/joshrotenberg/jmespath-extensions/pull/288))
+- *(mcp)* add discovery and analysis tools for AI agents ([#283](https://github.com/joshrotenberg/jmespath-extensions/pull/283))
+- *(string)* add shell_escape function (jq parity) ([#264](https://github.com/joshrotenberg/jmespath-extensions/pull/264))
+- *(expression)* add recurse, while_expr, and until_expr functions (jq parity) ([#261](https://github.com/joshrotenberg/jmespath-extensions/pull/261))
+- add cartesian N-way product and with_entries (jq parity) ([#257](https://github.com/joshrotenberg/jmespath-extensions/pull/257))
+- add from_csv and from_tsv functions for CSV/TSV parsing ([#256](https://github.com/joshrotenberg/jmespath-extensions/pull/256))
+- add jq-parity array functions (indices_array, inside_array, bsearch) ([#255](https://github.com/joshrotenberg/jmespath-extensions/pull/255))
+- *(object)* add safe path navigation with defaults ([#209](https://github.com/joshrotenberg/jmespath-extensions/pull/209)) ([#223](https://github.com/joshrotenberg/jmespath-extensions/pull/223))
+- add batch functions for issues #200, #201, #202, #206, #211 ([#222](https://github.com/joshrotenberg/jmespath-extensions/pull/222))
+- *(object)* add recursive key search and transformation functions ([#219](https://github.com/joshrotenberg/jmespath-extensions/pull/219))
+- *(object)* add data redaction/masking functions ([#218](https://github.com/joshrotenberg/jmespath-extensions/pull/218))
+- *(object)* add data quality scoring functions ([#221](https://github.com/joshrotenberg/jmespath-extensions/pull/221))
+- *(math)* add quartiles, outliers_iqr, outliers_zscore functions ([#198](https://github.com/joshrotenberg/jmespath-extensions/pull/198)) ([#220](https://github.com/joshrotenberg/jmespath-extensions/pull/220))
+- *(type)* add type parsing/coercion functions ([#217](https://github.com/joshrotenberg/jmespath-extensions/pull/217))
+- *(object)* add null/empty cleanup functions ([#216](https://github.com/joshrotenberg/jmespath-extensions/pull/216))
+- *(array)* add index_by function for array-to-lookup-map conversion ([#215](https://github.com/joshrotenberg/jmespath-extensions/pull/215))
+- *(object)* add flatten/unflatten aliases and flatten_array function ([#214](https://github.com/joshrotenberg/jmespath-extensions/pull/214))
+- *(fuzzy)* add missing strsim functions ([#196](https://github.com/joshrotenberg/jmespath-extensions/pull/196))
+- *(language)* add language detection functions using whatlang ([#197](https://github.com/joshrotenberg/jmespath-extensions/pull/197))
+
+### Fixed
+
+- make Category match statements exhaustive for compile-time safety ([#213](https://github.com/joshrotenberg/jmespath-extensions/pull/213))
+
+### Other
+
+- acknowledge JMESPath project and add jq comparison ([#279](https://github.com/joshrotenberg/jmespath-extensions/pull/279))
+- add JMESPath compliance test suite integration ([#164](https://github.com/joshrotenberg/jmespath-extensions/pull/164)) ([#226](https://github.com/joshrotenberg/jmespath-extensions/pull/226))
+- add examples for recently added functions ([#225](https://github.com/joshrotenberg/jmespath-extensions/pull/225))
+- fix MCP documentation link ([#195](https://github.com/joshrotenberg/jmespath-extensions/pull/195))
+- highlight MCP server in main README ([#193](https://github.com/joshrotenberg/jmespath-extensions/pull/193))
+
 ## [0.7.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.6.3...v0.7.0) - 2025-12-18
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.15...jpx-v0.1.16) - 2026-01-14
+
+### Added
+
+- *(discovery)* BM25 search quality improvements ([#296](https://github.com/joshrotenberg/jmespath-extensions/pull/296))
+- *(mcp)* add BM25 search indexing and discovery protocol ([#291](https://github.com/joshrotenberg/jmespath-extensions/pull/291))
+- *(discovery)* add fuzzy_search, fuzzy_match, and fuzzy_score functions ([#288](https://github.com/joshrotenberg/jmespath-extensions/pull/288))
+- *(mcp)* add discovery and analysis tools for AI agents ([#283](https://github.com/joshrotenberg/jmespath-extensions/pull/283))
+- *(cli)* add --stream flag for line-by-line NDJSON processing ([#281](https://github.com/joshrotenberg/jmespath-extensions/pull/281))
+- *(cli)* add config file support with TOML ([#278](https://github.com/joshrotenberg/jmespath-extensions/pull/278))
+- *(cli)* add --debug flag for diagnostic information ([#277](https://github.com/joshrotenberg/jmespath-extensions/pull/277))
+- *(cli)* add --similar flag to find related functions ([#272](https://github.com/joshrotenberg/jmespath-extensions/pull/272))
+- *(cli)* add --bench flag for expression benchmarking ([#269](https://github.com/joshrotenberg/jmespath-extensions/pull/269))
+- *(cli)* add --paths and --table flags ([#267](https://github.com/joshrotenberg/jmespath-extensions/pull/267))
+- *(cli)* add output format options (--yaml, --toml, --csv, --tsv, --lines) ([#266](https://github.com/joshrotenberg/jmespath-extensions/pull/266))
+- *(cli)* add --stats flag for quick data inspection ([#265](https://github.com/joshrotenberg/jmespath-extensions/pull/265))
+- *(cli)* support multiple positional expressions as pipeline ([#262](https://github.com/joshrotenberg/jmespath-extensions/pull/262))
+- *(cli)* add --diff, --patch, and --merge flags for JSON Patch operations ([#243](https://github.com/joshrotenberg/jmespath-extensions/pull/243))
+- *(cli)* add colored output and --search flag for function discovery ([#234](https://github.com/joshrotenberg/jmespath-extensions/pull/234))
+
+### Fixed
+
+- *(mcp)* Parameters<()> schema bug + mock server + BM25 improvements issue ([#294](https://github.com/joshrotenberg/jmespath-extensions/pull/294))
+- *(cli)* prefix all error messages with 'jpx:' ([#276](https://github.com/joshrotenberg/jmespath-extensions/pull/276))
+- make Category match statements exhaustive for compile-time safety ([#213](https://github.com/joshrotenberg/jmespath-extensions/pull/213))
+- add language category to MCP parse_category ([#212](https://github.com/joshrotenberg/jmespath-extensions/pull/212))
+
+### Other
+
+- acknowledge JMESPath project and add jq comparison ([#279](https://github.com/joshrotenberg/jmespath-extensions/pull/279))
+- add comprehensive integration tests for jpx CLI and MCP server ([#224](https://github.com/joshrotenberg/jmespath-extensions/pull/224))
+
 ## [0.1.15](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.14...jpx-v0.1.15) - 2026-01-12
 
 ### Added

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.15"
+version = "0.1.16"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `jpx`: 0.1.15 -> 0.1.16 (✓ API compatible changes)

### ⚠ `jmespath_extensions` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant Category:Language in /tmp/.tmphma9PG/jmespath-extensions/jmespath_extensions/src/registry.rs:97
  variant Category:Discovery in /tmp/.tmphma9PG/jmespath-extensions/jmespath_extensions/src/registry.rs:98
  variant Feature:discovery in /tmp/.tmphma9PG/jmespath-extensions/jmespath_extensions/src/registry.rs:332
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.8.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.7.0...v0.8.0) - 2026-01-14

### Added

- *(discovery)* add fuzzy_search, fuzzy_match, and fuzzy_score functions ([#288](https://github.com/joshrotenberg/jmespath-extensions/pull/288))
- *(mcp)* add discovery and analysis tools for AI agents ([#283](https://github.com/joshrotenberg/jmespath-extensions/pull/283))
- *(string)* add shell_escape function (jq parity) ([#264](https://github.com/joshrotenberg/jmespath-extensions/pull/264))
- *(expression)* add recurse, while_expr, and until_expr functions (jq parity) ([#261](https://github.com/joshrotenberg/jmespath-extensions/pull/261))
- add cartesian N-way product and with_entries (jq parity) ([#257](https://github.com/joshrotenberg/jmespath-extensions/pull/257))
- add from_csv and from_tsv functions for CSV/TSV parsing ([#256](https://github.com/joshrotenberg/jmespath-extensions/pull/256))
- add jq-parity array functions (indices_array, inside_array, bsearch) ([#255](https://github.com/joshrotenberg/jmespath-extensions/pull/255))
- *(object)* add safe path navigation with defaults ([#209](https://github.com/joshrotenberg/jmespath-extensions/pull/209)) ([#223](https://github.com/joshrotenberg/jmespath-extensions/pull/223))
- add batch functions for issues #200, #201, #202, #206, #211 ([#222](https://github.com/joshrotenberg/jmespath-extensions/pull/222))
- *(object)* add recursive key search and transformation functions ([#219](https://github.com/joshrotenberg/jmespath-extensions/pull/219))
- *(object)* add data redaction/masking functions ([#218](https://github.com/joshrotenberg/jmespath-extensions/pull/218))
- *(object)* add data quality scoring functions ([#221](https://github.com/joshrotenberg/jmespath-extensions/pull/221))
- *(math)* add quartiles, outliers_iqr, outliers_zscore functions ([#198](https://github.com/joshrotenberg/jmespath-extensions/pull/198)) ([#220](https://github.com/joshrotenberg/jmespath-extensions/pull/220))
- *(type)* add type parsing/coercion functions ([#217](https://github.com/joshrotenberg/jmespath-extensions/pull/217))
- *(object)* add null/empty cleanup functions ([#216](https://github.com/joshrotenberg/jmespath-extensions/pull/216))
- *(array)* add index_by function for array-to-lookup-map conversion ([#215](https://github.com/joshrotenberg/jmespath-extensions/pull/215))
- *(object)* add flatten/unflatten aliases and flatten_array function ([#214](https://github.com/joshrotenberg/jmespath-extensions/pull/214))
- *(fuzzy)* add missing strsim functions ([#196](https://github.com/joshrotenberg/jmespath-extensions/pull/196))
- *(language)* add language detection functions using whatlang ([#197](https://github.com/joshrotenberg/jmespath-extensions/pull/197))

### Fixed

- make Category match statements exhaustive for compile-time safety ([#213](https://github.com/joshrotenberg/jmespath-extensions/pull/213))

### Other

- acknowledge JMESPath project and add jq comparison ([#279](https://github.com/joshrotenberg/jmespath-extensions/pull/279))
- add JMESPath compliance test suite integration ([#164](https://github.com/joshrotenberg/jmespath-extensions/pull/164)) ([#226](https://github.com/joshrotenberg/jmespath-extensions/pull/226))
- add examples for recently added functions ([#225](https://github.com/joshrotenberg/jmespath-extensions/pull/225))
- fix MCP documentation link ([#195](https://github.com/joshrotenberg/jmespath-extensions/pull/195))
- highlight MCP server in main README ([#193](https://github.com/joshrotenberg/jmespath-extensions/pull/193))
</blockquote>

## `jpx`

<blockquote>

## [0.1.16](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.15...jpx-v0.1.16) - 2026-01-14

### Added

- *(discovery)* BM25 search quality improvements ([#296](https://github.com/joshrotenberg/jmespath-extensions/pull/296))
- *(mcp)* add BM25 search indexing and discovery protocol ([#291](https://github.com/joshrotenberg/jmespath-extensions/pull/291))
- *(discovery)* add fuzzy_search, fuzzy_match, and fuzzy_score functions ([#288](https://github.com/joshrotenberg/jmespath-extensions/pull/288))
- *(mcp)* add discovery and analysis tools for AI agents ([#283](https://github.com/joshrotenberg/jmespath-extensions/pull/283))
- *(cli)* add --stream flag for line-by-line NDJSON processing ([#281](https://github.com/joshrotenberg/jmespath-extensions/pull/281))
- *(cli)* add config file support with TOML ([#278](https://github.com/joshrotenberg/jmespath-extensions/pull/278))
- *(cli)* add --debug flag for diagnostic information ([#277](https://github.com/joshrotenberg/jmespath-extensions/pull/277))
- *(cli)* add --similar flag to find related functions ([#272](https://github.com/joshrotenberg/jmespath-extensions/pull/272))
- *(cli)* add --bench flag for expression benchmarking ([#269](https://github.com/joshrotenberg/jmespath-extensions/pull/269))
- *(cli)* add --paths and --table flags ([#267](https://github.com/joshrotenberg/jmespath-extensions/pull/267))
- *(cli)* add output format options (--yaml, --toml, --csv, --tsv, --lines) ([#266](https://github.com/joshrotenberg/jmespath-extensions/pull/266))
- *(cli)* add --stats flag for quick data inspection ([#265](https://github.com/joshrotenberg/jmespath-extensions/pull/265))
- *(cli)* support multiple positional expressions as pipeline ([#262](https://github.com/joshrotenberg/jmespath-extensions/pull/262))
- *(cli)* add --diff, --patch, and --merge flags for JSON Patch operations ([#243](https://github.com/joshrotenberg/jmespath-extensions/pull/243))
- *(cli)* add colored output and --search flag for function discovery ([#234](https://github.com/joshrotenberg/jmespath-extensions/pull/234))

### Fixed

- *(mcp)* Parameters<()> schema bug + mock server + BM25 improvements issue ([#294](https://github.com/joshrotenberg/jmespath-extensions/pull/294))
- *(cli)* prefix all error messages with 'jpx:' ([#276](https://github.com/joshrotenberg/jmespath-extensions/pull/276))
- make Category match statements exhaustive for compile-time safety ([#213](https://github.com/joshrotenberg/jmespath-extensions/pull/213))
- add language category to MCP parse_category ([#212](https://github.com/joshrotenberg/jmespath-extensions/pull/212))

### Other

- acknowledge JMESPath project and add jq comparison ([#279](https://github.com/joshrotenberg/jmespath-extensions/pull/279))
- add comprehensive integration tests for jpx CLI and MCP server ([#224](https://github.com/joshrotenberg/jmespath-extensions/pull/224))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).