### PR TITLE
docs: fix MCP documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use jpx as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) s
 
 **12 tools available:** `evaluate`, `evaluate_file`, `batch_evaluate`, `functions`, `describe`, `categories`, `validate`, `format`, `diff`, `patch`, `merge`, `keys`
 
-See [jpx MCP documentation](jpx/MCP.md) for details.
+See the [jpx README](jpx/README.md) for details.
 
 ---
 


### PR DESCRIPTION
Fixes broken link - jpx/MCP.md doesn't exist, points to jpx/README.md instead.