### PR TITLE
feat(fuzzy): add missing strsim functions

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "jpx",
+      "args": ["mcp"]
+    },
+    "jpx-strict": {
+      "command": "jpx",
+      "args": ["mcp", "--strict"]
+    }
+  }
+}

--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -1456,6 +1456,42 @@ examples = [
 ]
 features = ["core"]
 
+[[functions]]
+name = "normalized_damerau_levenshtein"
+category = "fuzzy"
+description = "Normalized Damerau-Levenshtein similarity (0-1)"
+signature = "string, string -> number"
+examples = [
+    { code = "normalized_damerau_levenshtein('hello', 'hello') -> 1.0", description = "Identical strings" },
+    { code = "normalized_damerau_levenshtein('ab', 'ba') -> 0.5", description = "Transposition" },
+    { code = "normalized_damerau_levenshtein('abc', 'xyz') -> 0.0", description = "Completely different" },
+]
+features = ["core"]
+
+[[functions]]
+name = "hamming"
+category = "fuzzy"
+description = "Hamming distance (number of differing positions). Returns null if strings have different lengths"
+signature = "string, string -> number|null"
+examples = [
+    { code = "hamming('karolin', 'kathrin') -> 3", description = "Three differing positions" },
+    { code = "hamming('hello', 'hello') -> 0", description = "Identical strings" },
+    { code = "hamming('hello', 'hi') -> null", description = "Different lengths" },
+]
+features = ["core"]
+
+[[functions]]
+name = "osa_distance"
+category = "fuzzy"
+description = "Optimal String Alignment distance (like Levenshtein but allows adjacent transpositions)"
+signature = "string, string -> number"
+examples = [
+    { code = "osa_distance('ab', 'ba') -> 1", description = "Single transposition" },
+    { code = "osa_distance('hello', 'hello') -> 0", description = "Identical strings" },
+    { code = "osa_distance('ca', 'abc') -> 3", description = "Multiple edits" },
+]
+features = ["core"]
+
 # =============================================================================
 # GEO FUNCTIONS
 # =============================================================================

--- a/jmespath_extensions/src/fuzzy.rs
+++ b/jmespath_extensions/src/fuzzy.rs
@@ -29,9 +29,15 @@ pub fn register(runtime: &mut Runtime) {
         Box::new(NormalizedLevenshteinFn::new()),
     );
     runtime.register_function("damerau_levenshtein", Box::new(DamerauLevenshteinFn::new()));
+    runtime.register_function(
+        "normalized_damerau_levenshtein",
+        Box::new(NormalizedDamerauLevenshteinFn::new()),
+    );
     runtime.register_function("jaro", Box::new(JaroFn::new()));
     runtime.register_function("jaro_winkler", Box::new(JaroWinklerFn::new()));
     runtime.register_function("sorensen_dice", Box::new(SorensenDiceFn::new()));
+    runtime.register_function("hamming", Box::new(HammingFn::new()));
+    runtime.register_function("osa_distance", Box::new(OsaDistanceFn::new()));
 }
 
 // levenshtein(s1, s2) -> number
@@ -148,6 +154,65 @@ impl Function for SorensenDiceFn {
     }
 }
 
+// normalized_damerau_levenshtein(s1, s2) -> number (0.0-1.0)
+define_function!(
+    NormalizedDamerauLevenshteinFn,
+    vec![ArgumentType::String, ArgumentType::String],
+    None
+);
+
+impl Function for NormalizedDamerauLevenshteinFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        let s1 = args[0].as_string().unwrap();
+        let s2 = args[1].as_string().unwrap();
+        let sim = strsim::normalized_damerau_levenshtein(s1, s2);
+        Ok(Rc::new(Variable::Number(
+            serde_json::Number::from_f64(sim).unwrap(),
+        )))
+    }
+}
+
+// hamming(s1, s2) -> number (returns null if strings have different lengths)
+define_function!(
+    HammingFn,
+    vec![ArgumentType::String, ArgumentType::String],
+    None
+);
+
+impl Function for HammingFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        let s1 = args[0].as_string().unwrap();
+        let s2 = args[1].as_string().unwrap();
+        match strsim::hamming(s1, s2) {
+            Ok(dist) => Ok(Rc::new(Variable::Number(
+                serde_json::Number::from_f64(dist as f64).unwrap(),
+            ))),
+            Err(_) => Ok(Rc::new(Variable::Null)), // Different lengths
+        }
+    }
+}
+
+// osa_distance(s1, s2) -> number (Optimal String Alignment distance)
+define_function!(
+    OsaDistanceFn,
+    vec![ArgumentType::String, ArgumentType::String],
+    None
+);
+
+impl Function for OsaDistanceFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        let s1 = args[0].as_string().unwrap();
+        let s2 = args[1].as_string().unwrap();
+        let dist = strsim::osa_distance(s1, s2);
+        Ok(Rc::new(Variable::Number(
+            serde_json::Number::from_f64(dist as f64).unwrap(),
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,5 +325,69 @@ mod tests {
         let expr = runtime.compile("sorensen_dice('test', 'test')").unwrap();
         let result = expr.search(&Variable::Null).unwrap();
         assert_eq!(result.as_number().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_normalized_damerau_levenshtein() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("normalized_damerau_levenshtein('hello', 'hello')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_number().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_normalized_damerau_levenshtein_transposition() {
+        let runtime = setup();
+        // "ab" vs "ba" - transposition
+        let expr = runtime
+            .compile("normalized_damerau_levenshtein('ab', 'ba')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        let sim = result.as_number().unwrap();
+        assert!(sim > 0.0 && sim < 1.0);
+    }
+
+    #[test]
+    fn test_hamming() {
+        let runtime = setup();
+        let expr = runtime.compile("hamming('karolin', 'kathrin')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_number().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_hamming_identical() {
+        let runtime = setup();
+        let expr = runtime.compile("hamming('hello', 'hello')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_number().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_hamming_different_lengths() {
+        let runtime = setup();
+        // Different lengths should return null
+        let expr = runtime.compile("hamming('hello', 'hi')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_osa_distance() {
+        let runtime = setup();
+        // OSA allows transpositions
+        let expr = runtime.compile("osa_distance('ab', 'ba')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_number().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_osa_distance_identical() {
+        let runtime = setup();
+        let expr = runtime.compile("osa_distance('hello', 'hello')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_number().unwrap(), 0.0);
     }
 }


### PR DESCRIPTION
Adds three additional string similarity functions from the strsim crate that were missing:

| Function | Description |
|----------|-------------|
| `normalized_damerau_levenshtein` | Normalized 0-1 version of Damerau-Levenshtein |
| `hamming` | Count differing positions (returns null for different lengths) |
| `osa_distance` | Optimal String Alignment distance (Levenshtein with adjacent transpositions) |

This completes coverage of all strsim functions. No new dependencies needed since strsim is already used.

**Examples:**
```
normalized_damerau_levenshtein('hello', 'hello') -> 1.0
hamming('karolin', 'kathrin') -> 3
hamming('hello', 'hi') -> null  # different lengths
osa_distance('ab', 'ba') -> 1
```