### PR TITLE
feat(language): add language detection functions using whatlang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +601,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +752,17 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -932,7 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1017,6 +1040,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "whatlang",
 ]
 
 [[package]]
@@ -2297,6 +2321,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whatlang"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e8f38b596e2a359b755342473520a99421e43658548c79489ee221b728c107"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ulid = "1.1"
 json-patch = "4.0"
 aho-corasick = "1.1"
 csv = "1.3"
+whatlang = "0.18"
 
 # MCP server dependencies
 rmcp = { version = "0.12", features = ["server", "transport-io", "macros"] }

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -41,10 +41,11 @@ ulid = { workspace = true, optional = true }
 json-patch = { workspace = true, optional = true }
 aho-corasick = { workspace = true, optional = true }
 csv = { workspace = true, optional = true }
+whatlang = { workspace = true, optional = true }
 
 [features]
 default = ["full"]
-full = ["string", "array", "object", "math", "type", "utility", "validation", "path", "hash", "encoding", "regex", "url", "uuid", "rand", "datetime", "fuzzy", "expression", "phonetic", "geo", "semver", "network", "ids", "text", "duration", "color", "computing", "jsonpatch", "multi-match", "format"]
+full = ["string", "array", "object", "math", "type", "utility", "validation", "path", "hash", "encoding", "regex", "url", "uuid", "rand", "datetime", "fuzzy", "expression", "phonetic", "geo", "semver", "network", "ids", "text", "duration", "color", "computing", "jsonpatch", "multi-match", "format", "language"]
 core = ["string", "array", "object", "math", "type", "utility", "validation", "path", "expression"]
 string = []
 array = []
@@ -75,6 +76,7 @@ computing = []
 jsonpatch = ["dep:json-patch"]
 multi-match = ["dep:aho-corasick"]
 format = ["dep:csv"]
+language = ["dep:whatlang"]
 # env feature is opt-in (not in full) as it can expose sensitive environment data
 env = []
 

--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -4317,3 +4317,71 @@ examples = [
     { code = "default(get_env('PORT'), '8080') -> with fallback", description = "With default value" },
 ]
 features = ["env"]
+
+# =============================================================================
+# LANGUAGE DETECTION FUNCTIONS
+# =============================================================================
+
+[[functions]]
+name = "detect_language"
+category = "language"
+description = "Detect the language of text, returning the native language name"
+signature = "string -> string | null"
+examples = [
+    { code = '''detect_language('This is English text.') -> \"English\"''', description = "Detect English" },
+    { code = '''detect_language('Esto es texto en español.') -> \"Español\"''', description = "Detect Spanish (native name)" },
+    { code = '''detect_language('Ceci est du texte français.') -> \"Français\"''', description = "Detect French (native name)" },
+    { code = "detect_language('') -> null", description = "Empty or undetectable returns null" },
+]
+features = ["core"]
+
+[[functions]]
+name = "detect_language_iso"
+category = "language"
+description = "Detect the language of text, returning the ISO 639-3 code"
+signature = "string -> string | null"
+examples = [
+    { code = '''detect_language_iso('This is English text.') -> \"eng\"''', description = "English ISO code" },
+    { code = '''detect_language_iso('Esto es texto en español.') -> \"spa\"''', description = "Spanish ISO code" },
+    { code = '''detect_language_iso('Dies ist deutscher Text.') -> \"deu\"''', description = "German ISO code" },
+    { code = "detect_language_iso('') -> null", description = "Empty or undetectable returns null" },
+]
+features = ["core"]
+
+[[functions]]
+name = "detect_script"
+category = "language"
+description = "Detect the script (writing system) of text"
+signature = "string -> string | null"
+examples = [
+    { code = '''detect_script('Hello world') -> \"Latin\"''', description = "Latin script" },
+    { code = '''detect_script('Привет мир') -> \"Cyrillic\"''', description = "Cyrillic script" },
+    { code = '''detect_script('مرحبا بالعالم') -> \"Arabic\"''', description = "Arabic script" },
+    { code = '''detect_script('こんにちは') -> \"Hiragana\"''', description = "Japanese Hiragana" },
+]
+features = ["core"]
+
+[[functions]]
+name = "detect_language_confidence"
+category = "language"
+description = "Detect language and return confidence score (0.0-1.0)"
+signature = "string -> number | null"
+examples = [
+    { code = "detect_language_confidence('This is definitely English text.') -> 0.95", description = "High confidence" },
+    { code = "detect_language_confidence('Hi') -> 0.3", description = "Low confidence for short text" },
+    { code = "detect_language_confidence('') -> null", description = "Empty returns null" },
+]
+features = ["core"]
+
+[[functions]]
+name = "detect_language_info"
+category = "language"
+description = "Detect language and return full detection info object"
+signature = "string -> object | null"
+examples = [
+    { code = "detect_language_info('This is a test.') -> {language: 'English', code: 'eng', script: 'Latin', confidence: 0.9, reliable: true}", description = "Full detection info" },
+    { code = "detect_language_info('Bonjour').language -> 'French'", description = "Access language field" },
+    { code = "detect_language_info('Hola').reliable -> true/false", description = "Check reliability" },
+    { code = "detect_language_info('') -> null", description = "Empty returns null" },
+]
+features = ["core"]

--- a/jmespath_extensions/src/language.rs
+++ b/jmespath_extensions/src/language.rs
@@ -1,0 +1,316 @@
+//! Language detection functions.
+//!
+//! This module provides language detection functions for JMESPath queries
+//! using the whatlang crate.
+//!
+//! For complete function reference with signatures and examples, see the
+//! [`functions`](crate::functions) module documentation or use `jpx --list-category language`.
+//!
+//! # Example
+//!
+//! ```rust
+//! use jmespath::{Runtime, Variable};
+//! use jmespath_extensions::language;
+//!
+//! let mut runtime = Runtime::new();
+//! runtime.register_builtin_functions();
+//! language::register(&mut runtime);
+//! ```
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::common::Function;
+use crate::{ArgumentType, Context, JmespathError, Rcvar, Runtime, Variable, define_function};
+
+/// Register all language detection functions with the runtime.
+pub fn register(runtime: &mut Runtime) {
+    runtime.register_function("detect_language", Box::new(DetectLanguageFn::new()));
+    runtime.register_function("detect_language_iso", Box::new(DetectLanguageIsoFn::new()));
+    runtime.register_function("detect_script", Box::new(DetectScriptFn::new()));
+    runtime.register_function(
+        "detect_language_confidence",
+        Box::new(DetectLanguageConfidenceFn::new()),
+    );
+    runtime.register_function(
+        "detect_language_info",
+        Box::new(DetectLanguageInfoFn::new()),
+    );
+}
+
+// =============================================================================
+// detect_language(text) -> string (full name like "English")
+// =============================================================================
+
+define_function!(DetectLanguageFn, vec![ArgumentType::String], None);
+
+impl Function for DetectLanguageFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        let text = args[0].as_string().unwrap();
+
+        match whatlang::detect(text) {
+            Some(info) => {
+                let name = info.lang().to_string();
+                Ok(Rc::new(Variable::String(name)))
+            }
+            None => Ok(Rc::new(Variable::Null)),
+        }
+    }
+}
+
+// =============================================================================
+// detect_language_iso(text) -> string (ISO 639-3 code like "eng")
+// =============================================================================
+
+define_function!(DetectLanguageIsoFn, vec![ArgumentType::String], None);
+
+impl Function for DetectLanguageIsoFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        let text = args[0].as_string().unwrap();
+
+        match whatlang::detect(text) {
+            Some(info) => {
+                let code = info.lang().code();
+                Ok(Rc::new(Variable::String(code.to_string())))
+            }
+            None => Ok(Rc::new(Variable::Null)),
+        }
+    }
+}
+
+// =============================================================================
+// detect_script(text) -> string (script name like "Latin")
+// =============================================================================
+
+define_function!(DetectScriptFn, vec![ArgumentType::String], None);
+
+impl Function for DetectScriptFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        let text = args[0].as_string().unwrap();
+
+        match whatlang::detect(text) {
+            Some(info) => {
+                let script = format!("{:?}", info.script());
+                Ok(Rc::new(Variable::String(script)))
+            }
+            None => Ok(Rc::new(Variable::Null)),
+        }
+    }
+}
+
+// =============================================================================
+// detect_language_confidence(text) -> number (0.0-1.0)
+// =============================================================================
+
+define_function!(DetectLanguageConfidenceFn, vec![ArgumentType::String], None);
+
+impl Function for DetectLanguageConfidenceFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        let text = args[0].as_string().unwrap();
+
+        match whatlang::detect(text) {
+            Some(info) => Ok(Rc::new(Variable::Number(
+                serde_json::Number::from_f64(info.confidence()).unwrap(),
+            ))),
+            None => Ok(Rc::new(Variable::Null)),
+        }
+    }
+}
+
+// =============================================================================
+// detect_language_info(text) -> object with full detection info
+// =============================================================================
+
+define_function!(DetectLanguageInfoFn, vec![ArgumentType::String], None);
+
+impl Function for DetectLanguageInfoFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        let text = args[0].as_string().unwrap();
+
+        match whatlang::detect(text) {
+            Some(info) => {
+                let mut result: BTreeMap<String, Rcvar> = BTreeMap::new();
+
+                result.insert(
+                    "language".to_string(),
+                    Rc::new(Variable::String(info.lang().to_string())),
+                );
+                result.insert(
+                    "code".to_string(),
+                    Rc::new(Variable::String(info.lang().code().to_string())),
+                );
+                result.insert(
+                    "script".to_string(),
+                    Rc::new(Variable::String(format!("{:?}", info.script()))),
+                );
+                result.insert(
+                    "confidence".to_string(),
+                    Rc::new(Variable::Number(
+                        serde_json::Number::from_f64(info.confidence()).unwrap(),
+                    )),
+                );
+                result.insert(
+                    "reliable".to_string(),
+                    Rc::new(Variable::Bool(info.is_reliable())),
+                );
+
+                Ok(Rc::new(Variable::Object(result)))
+            }
+            None => Ok(Rc::new(Variable::Null)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Runtime {
+        let mut runtime = Runtime::new();
+        runtime.register_builtin_functions();
+        register(&mut runtime);
+        runtime
+    }
+
+    #[test]
+    fn test_detect_language_english() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("detect_language('This is a test of the language detection system.')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_string().unwrap(), "English");
+    }
+
+    #[test]
+    fn test_detect_language_spanish() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("detect_language('Esto es una prueba del sistema de deteccion de idiomas.')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        // whatlang returns native language names
+        assert_eq!(result.as_string().unwrap(), "Español");
+    }
+
+    #[test]
+    fn test_detect_language_french() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("detect_language('Ceci est un test du systeme de detection de langue.')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        // whatlang returns native language names
+        assert_eq!(result.as_string().unwrap(), "Français");
+    }
+
+    #[test]
+    fn test_detect_language_german() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("detect_language('Dies ist ein Test des Spracherkennungssystems.')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        // whatlang returns native language names
+        assert_eq!(result.as_string().unwrap(), "Deutsch");
+    }
+
+    #[test]
+    fn test_detect_language_iso_english() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("detect_language_iso('This is English text.')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_string().unwrap(), "eng");
+    }
+
+    #[test]
+    fn test_detect_language_iso_spanish() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("detect_language_iso('Este es un texto en espanol.')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_string().unwrap(), "spa");
+    }
+
+    #[test]
+    fn test_detect_script_latin() {
+        let runtime = setup();
+        let expr = runtime.compile("detect_script('Hello world')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_string().unwrap(), "Latin");
+    }
+
+    #[test]
+    fn test_detect_script_cyrillic() {
+        let runtime = setup();
+        let expr = runtime.compile("detect_script('Привет мир')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_string().unwrap(), "Cyrillic");
+    }
+
+    #[test]
+    fn test_detect_script_arabic() {
+        let runtime = setup();
+        let expr = runtime.compile("detect_script('مرحبا بالعالم')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        assert_eq!(result.as_string().unwrap(), "Arabic");
+    }
+
+    #[test]
+    fn test_detect_language_confidence() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("detect_language_confidence('This is definitely English text for testing.')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        let confidence = result.as_number().unwrap();
+        assert!(confidence > 0.5);
+    }
+
+    #[test]
+    fn test_detect_language_info() {
+        let runtime = setup();
+        let expr = runtime
+            .compile("detect_language_info('This is a test.')")
+            .unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        let obj = result.as_object().unwrap();
+
+        assert!(obj.contains_key("language"));
+        assert!(obj.contains_key("code"));
+        assert!(obj.contains_key("script"));
+        assert!(obj.contains_key("confidence"));
+        assert!(obj.contains_key("reliable"));
+
+        assert_eq!(obj.get("language").unwrap().as_string().unwrap(), "English");
+        assert_eq!(obj.get("code").unwrap().as_string().unwrap(), "eng");
+        assert_eq!(obj.get("script").unwrap().as_string().unwrap(), "Latin");
+    }
+
+    #[test]
+    fn test_detect_language_empty_string() {
+        let runtime = setup();
+        let expr = runtime.compile("detect_language('')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        // Empty string may return null or a guess
+        // Just verify it doesn't crash
+        assert!(result.is_null() || result.as_string().is_some());
+    }
+
+    #[test]
+    fn test_detect_language_short_text() {
+        let runtime = setup();
+        let expr = runtime.compile("detect_language('Hi')").unwrap();
+        let result = expr.search(&Variable::Null).unwrap();
+        // Short text may have low confidence but should still work
+        assert!(result.is_null() || result.as_string().is_some());
+    }
+}

--- a/jmespath_extensions/src/lib.rs
+++ b/jmespath_extensions/src/lib.rs
@@ -347,6 +347,9 @@ pub mod multi_match;
 #[cfg(feature = "format")]
 pub mod format;
 
+#[cfg(feature = "language")]
+pub mod language;
+
 /// Register all available extension functions with a JMESPath runtime.
 ///
 /// This function registers all functions enabled by the current feature flags.
@@ -462,6 +465,9 @@ pub fn register_all(runtime: &mut Runtime) {
 
     #[cfg(feature = "format")]
     format::register(runtime);
+
+    #[cfg(feature = "language")]
+    language::register(runtime);
 }
 
 #[cfg(test)]

--- a/jmespath_extensions/src/registry.rs
+++ b/jmespath_extensions/src/registry.rs
@@ -94,6 +94,7 @@ pub enum Category {
     MultiMatch,
     Jsonpatch,
     Format,
+    Language,
 }
 
 impl Category {
@@ -130,6 +131,7 @@ impl Category {
             Category::MultiMatch,
             Category::Jsonpatch,
             Category::Format,
+            Category::Language,
         ]
     }
 
@@ -166,6 +168,7 @@ impl Category {
             Category::MultiMatch => "multi-match",
             Category::Jsonpatch => "jsonpatch",
             Category::Format => "format",
+            Category::Language => "language",
         }
     }
 
@@ -232,6 +235,8 @@ impl Category {
             Category::Jsonpatch => true,
             #[cfg(feature = "format")]
             Category::Format => true,
+            #[cfg(feature = "language")]
+            Category::Language => true,
             #[allow(unreachable_patterns)]
             _ => false,
         }
@@ -537,6 +542,8 @@ impl FunctionRegistry {
             Category::Jsonpatch => crate::jsonpatch::register(runtime),
             #[cfg(feature = "format")]
             Category::Format => crate::format::register(runtime),
+            #[cfg(feature = "language")]
+            Category::Language => crate::language::register(runtime),
             #[allow(unreachable_patterns)]
             _ => {}
         }


### PR DESCRIPTION
## Summary

Add 5 new language detection functions powered by the lightweight [whatlang](https://github.com/greyblake/whatlang-rs) crate.

## New Functions

| Function | Description | Example |
|----------|-------------|---------|
| `detect_language(text)` | Returns native language name | `"English"`, `"Español"` |
| `detect_language_iso(text)` | Returns ISO 639-3 code | `"eng"`, `"spa"` |
| `detect_script(text)` | Returns script name | `"Latin"`, `"Cyrillic"` |
| `detect_language_confidence(text)` | Returns confidence (0.0-1.0) | `0.95` |
| `detect_language_info(text)` | Returns full detection object | `{language, code, script, confidence, reliable}` |

## Why whatlang over lingua?

| Crate | Binary Size | Dependencies |
|-------|-------------|--------------|
| whatlang | +695KB | 5 |
| lingua | +93MB | 252 |

whatlang is **134x smaller** while still supporting 70 languages with trigram-based detection.

## Feature Flag

Functions are available under the `language` feature flag, which is included in the default `full` feature.

```toml
jmespath_extensions = { version = "0.7", features = ["language"] }
```

## Tests

All 13 tests pass:
- Language detection (English, Spanish, French, German)
- ISO code detection
- Script detection (Latin, Cyrillic, Arabic)
- Confidence scoring
- Full info object
- Edge cases (empty/short text)