### PR TITLE
fix: add language category to MCP parse_category

### DIFF
--- a/jpx/src/mcp/tools.rs
+++ b/jpx/src/mcp/tools.rs
@@ -252,6 +252,7 @@ fn parse_category(name: &str) -> Option<Category> {
         "multimatch" => Some(Category::MultiMatch),
         "jsonpatch" => Some(Category::Jsonpatch),
         "format" => Some(Category::Format),
+        "language" => Some(Category::Language),
         _ => None,
     }
 }


### PR DESCRIPTION
Follow-up to #197 - adds the `language` category to the MCP server's `parse_category()` function so that `functions --category language` works correctly.