### PR TITLE
fix: make Category match statements exhaustive for compile-time safety

### DIFF
--- a/jmespath_extensions/src/registry.rs
+++ b/jmespath_extensions/src/registry.rs
@@ -237,8 +237,68 @@ impl Category {
             Category::Format => true,
             #[cfg(feature = "language")]
             Category::Language => true,
-            #[allow(unreachable_patterns)]
-            _ => false,
+            // Explicit false cases for when features are disabled.
+            // This ensures compile errors if a new category is added without handling it here.
+            #[cfg(not(feature = "string"))]
+            Category::String => false,
+            #[cfg(not(feature = "array"))]
+            Category::Array => false,
+            #[cfg(not(feature = "object"))]
+            Category::Object => false,
+            #[cfg(not(feature = "math"))]
+            Category::Math => false,
+            #[cfg(not(feature = "type"))]
+            Category::Type => false,
+            #[cfg(not(feature = "utility"))]
+            Category::Utility => false,
+            #[cfg(not(feature = "validation"))]
+            Category::Validation => false,
+            #[cfg(not(feature = "path"))]
+            Category::Path => false,
+            #[cfg(not(feature = "expression"))]
+            Category::Expression => false,
+            #[cfg(not(feature = "text"))]
+            Category::Text => false,
+            #[cfg(not(feature = "hash"))]
+            Category::Hash => false,
+            #[cfg(not(feature = "encoding"))]
+            Category::Encoding => false,
+            #[cfg(not(feature = "regex"))]
+            Category::Regex => false,
+            #[cfg(not(feature = "url"))]
+            Category::Url => false,
+            #[cfg(not(feature = "uuid"))]
+            Category::Uuid => false,
+            #[cfg(not(feature = "rand"))]
+            Category::Rand => false,
+            #[cfg(not(feature = "datetime"))]
+            Category::Datetime => false,
+            #[cfg(not(feature = "fuzzy"))]
+            Category::Fuzzy => false,
+            #[cfg(not(feature = "phonetic"))]
+            Category::Phonetic => false,
+            #[cfg(not(feature = "geo"))]
+            Category::Geo => false,
+            #[cfg(not(feature = "semver"))]
+            Category::Semver => false,
+            #[cfg(not(feature = "network"))]
+            Category::Network => false,
+            #[cfg(not(feature = "ids"))]
+            Category::Ids => false,
+            #[cfg(not(feature = "duration"))]
+            Category::Duration => false,
+            #[cfg(not(feature = "color"))]
+            Category::Color => false,
+            #[cfg(not(feature = "computing"))]
+            Category::Computing => false,
+            #[cfg(not(feature = "multi-match"))]
+            Category::MultiMatch => false,
+            #[cfg(not(feature = "jsonpatch"))]
+            Category::Jsonpatch => false,
+            #[cfg(not(feature = "format"))]
+            Category::Format => false,
+            #[cfg(not(feature = "language"))]
+            Category::Language => false,
         }
     }
 }
@@ -544,8 +604,69 @@ impl FunctionRegistry {
             Category::Format => crate::format::register(runtime),
             #[cfg(feature = "language")]
             Category::Language => crate::language::register(runtime),
-            #[allow(unreachable_patterns)]
-            _ => {}
+            // Explicit no-op cases for when features are disabled.
+            // This ensures compile errors if a new category is added without handling it here.
+            Category::Standard => {} // Standard functions are registered via runtime.register_builtin_functions()
+            #[cfg(not(feature = "string"))]
+            Category::String => {}
+            #[cfg(not(feature = "array"))]
+            Category::Array => {}
+            #[cfg(not(feature = "object"))]
+            Category::Object => {}
+            #[cfg(not(feature = "math"))]
+            Category::Math => {}
+            #[cfg(not(feature = "type"))]
+            Category::Type => {}
+            #[cfg(not(feature = "utility"))]
+            Category::Utility => {}
+            #[cfg(not(feature = "validation"))]
+            Category::Validation => {}
+            #[cfg(not(feature = "path"))]
+            Category::Path => {}
+            #[cfg(not(feature = "expression"))]
+            Category::Expression => {}
+            #[cfg(not(feature = "text"))]
+            Category::Text => {}
+            #[cfg(not(feature = "hash"))]
+            Category::Hash => {}
+            #[cfg(not(feature = "encoding"))]
+            Category::Encoding => {}
+            #[cfg(not(feature = "regex"))]
+            Category::Regex => {}
+            #[cfg(not(feature = "url"))]
+            Category::Url => {}
+            #[cfg(not(feature = "uuid"))]
+            Category::Uuid => {}
+            #[cfg(not(feature = "rand"))]
+            Category::Rand => {}
+            #[cfg(not(feature = "datetime"))]
+            Category::Datetime => {}
+            #[cfg(not(feature = "fuzzy"))]
+            Category::Fuzzy => {}
+            #[cfg(not(feature = "phonetic"))]
+            Category::Phonetic => {}
+            #[cfg(not(feature = "geo"))]
+            Category::Geo => {}
+            #[cfg(not(feature = "semver"))]
+            Category::Semver => {}
+            #[cfg(not(feature = "network"))]
+            Category::Network => {}
+            #[cfg(not(feature = "ids"))]
+            Category::Ids => {}
+            #[cfg(not(feature = "duration"))]
+            Category::Duration => {}
+            #[cfg(not(feature = "color"))]
+            Category::Color => {}
+            #[cfg(not(feature = "computing"))]
+            Category::Computing => {}
+            #[cfg(not(feature = "multi-match"))]
+            Category::MultiMatch => {}
+            #[cfg(not(feature = "jsonpatch"))]
+            Category::Jsonpatch => {}
+            #[cfg(not(feature = "format"))]
+            Category::Format => {}
+            #[cfg(not(feature = "language"))]
+            Category::Language => {}
         }
     }
 }

--- a/jpx/src/mcp/tools.rs
+++ b/jpx/src/mcp/tools.rs
@@ -219,42 +219,53 @@ pub struct BatchEvaluateResult {
 // Helper functions
 // =============================================================================
 
-/// Parse category string to Category enum
-fn parse_category(name: &str) -> Option<Category> {
-    match name.to_lowercase().as_str() {
-        "standard" => Some(Category::Standard),
-        "string" => Some(Category::String),
-        "array" => Some(Category::Array),
-        "object" => Some(Category::Object),
-        "math" => Some(Category::Math),
-        "type" => Some(Category::Type),
-        "utility" => Some(Category::Utility),
-        "validation" => Some(Category::Validation),
-        "path" => Some(Category::Path),
-        "expression" => Some(Category::Expression),
-        "text" => Some(Category::Text),
-        "hash" => Some(Category::Hash),
-        "encoding" => Some(Category::Encoding),
-        "regex" => Some(Category::Regex),
-        "url" => Some(Category::Url),
-        "uuid" => Some(Category::Uuid),
-        "rand" => Some(Category::Rand),
-        "datetime" => Some(Category::Datetime),
-        "fuzzy" => Some(Category::Fuzzy),
-        "phonetic" => Some(Category::Phonetic),
-        "geo" => Some(Category::Geo),
-        "semver" => Some(Category::Semver),
-        "network" => Some(Category::Network),
-        "ids" => Some(Category::Ids),
-        "duration" => Some(Category::Duration),
-        "color" => Some(Category::Color),
-        "computing" => Some(Category::Computing),
-        "multimatch" => Some(Category::MultiMatch),
-        "jsonpatch" => Some(Category::Jsonpatch),
-        "format" => Some(Category::Format),
-        "language" => Some(Category::Language),
-        _ => None,
+/// Get the string name for a category.
+/// This function uses exhaustive matching to ensure compile errors when new categories are added.
+fn category_to_string(category: Category) -> &'static str {
+    match category {
+        Category::Standard => "standard",
+        Category::String => "string",
+        Category::Array => "array",
+        Category::Object => "object",
+        Category::Math => "math",
+        Category::Type => "type",
+        Category::Utility => "utility",
+        Category::Validation => "validation",
+        Category::Path => "path",
+        Category::Expression => "expression",
+        Category::Text => "text",
+        Category::Hash => "hash",
+        Category::Encoding => "encoding",
+        Category::Regex => "regex",
+        Category::Url => "url",
+        Category::Uuid => "uuid",
+        Category::Rand => "rand",
+        Category::Datetime => "datetime",
+        Category::Fuzzy => "fuzzy",
+        Category::Phonetic => "phonetic",
+        Category::Geo => "geo",
+        Category::Semver => "semver",
+        Category::Network => "network",
+        Category::Ids => "ids",
+        Category::Duration => "duration",
+        Category::Color => "color",
+        Category::Computing => "computing",
+        Category::MultiMatch => "multimatch",
+        Category::Jsonpatch => "jsonpatch",
+        Category::Format => "format",
+        Category::Language => "language",
     }
+}
+
+/// Parse category string to Category enum.
+/// Note: When adding a new category, also add it to `category_to_string` above
+/// which will cause a compile error if missed.
+fn parse_category(name: &str) -> Option<Category> {
+    // Use Category::all() to ensure we check all categories
+    Category::all()
+        .iter()
+        .find(|cat| category_to_string(**cat) == name.to_lowercase())
+        .copied()
 }
 
 /// Create a successful text result


### PR DESCRIPTION
## Summary

Remove wildcard patterns from `Category` match statements so that adding a new category without updating all match arms causes a compile error.

## Problem

Previously, if you added a new `Category` variant but forgot to handle it in:
- `is_available()` 
- `apply_category()`
- `parse_category()` (MCP)

...it would silently fall through to the `_ => ...` wildcard and either return `false`, do nothing, or return `None`. This made it easy to forget to wire up new categories.

## Solution

### `registry.rs`

For `is_available()` and `apply_category()`, explicitly handle each category with both:
- `#[cfg(feature = "X")] Category::X => true/register`
- `#[cfg(not(feature = "X"))] Category::X => false/{}`

This ensures the match is exhaustive regardless of which features are enabled.

### `tools.rs` (MCP)

Replace the string-matching `parse_category()` with:
1. A new `category_to_string()` function that uses exhaustive matching
2. `parse_category()` now iterates `Category::all()` and uses `category_to_string()`

If you add a new category and forget to add it to `category_to_string()`, you get:

```
error[E0004]: non-exhaustive patterns: `Category::NewCategory` not covered
```

## Testing

- `cargo build --package jmespath_extensions --features full` ✓
- `cargo build --package jpx` ✓  
- `cargo test --package jpx` ✓ (28 tests pass)