### PR TITLE
feat(object): add flatten/unflatten aliases and flatten_array function

### DIFF
--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -2389,6 +2389,31 @@ examples = [
 features = ["core"]
 
 [[functions]]
+name = "flatten"
+category = "object"
+description = "Alias for flatten_keys - flatten nested object with dot notation keys"
+signature = "object -> object"
+examples = [
+    { code = '''flatten({a: {b: 1}}) -> {\"a.b\": 1}''', description = "Simple nested" },
+    { code = '''flatten({a: {b: {c: 1}}}) -> {\"a.b.c\": 1}''', description = "Deep nested" },
+    { code = '''flatten({a: 1, b: 2}) -> {\"a\": 1, \"b\": 2}''', description = "Flat object" },
+]
+features = ["core"]
+
+[[functions]]
+name = "flatten_array"
+category = "object"
+description = "Flatten nested objects and arrays with dot notation keys (arrays use numeric indices)"
+signature = "any, string? -> object"
+examples = [
+    { code = '''flatten_array({a: [1, 2]}) -> {\"a.0\": 1, \"a.1\": 2}''', description = "Array with indices" },
+    { code = '''flatten_array({a: {b: [1, 2]}}) -> {\"a.b.0\": 1, \"a.b.1\": 2}''', description = "Nested object with array" },
+    { code = '''flatten_array([{a: 1}, {b: 2}]) -> {\"0.a\": 1, \"1.b\": 2}''', description = "Array of objects" },
+    { code = '''flatten_array({a: {b: 1}}, '/') -> {\"a/b\": 1}''', description = "Custom separator" },
+]
+features = ["core"]
+
+[[functions]]
 name = "flatten_keys"
 category = "object"
 description = "Flatten nested object with dot notation keys"
@@ -2556,6 +2581,31 @@ examples = [
     { code = "set_path({a: 1}, '/a', `2`) -> {a: 2}", description = "Update existing" },
     { code = "set_path({a: {}}, '/a/b', `1`) -> {a: {b: 1}}", description = "Set nested path" },
     { code = "set_path([1, 2], '/1', `5`) -> [1, 5]", description = "Update array element" },
+]
+features = ["core"]
+
+[[functions]]
+name = "unflatten"
+category = "object"
+description = "Alias for unflatten_keys - restore nested object from dot notation keys"
+signature = "object -> object"
+examples = [
+    { code = '''unflatten({\"a.b\": 1}) -> {a: {b: 1}}''', description = "Simple nested" },
+    { code = '''unflatten({\"a.b.c\": 1}) -> {a: {b: {c: 1}}}''', description = "Deep nested" },
+    { code = '''unflatten({\"a\": 1, \"b\": 2}) -> {a: 1, b: 2}''', description = "Flat keys" },
+]
+features = ["core"]
+
+[[functions]]
+name = "unflatten_keys"
+category = "object"
+description = "Restore nested object from dot notation keys"
+signature = "object -> object"
+examples = [
+    { code = '''unflatten_keys({\"a.b\": 1}) -> {a: {b: 1}}''', description = "Simple nested" },
+    { code = '''unflatten_keys({\"a.b.c\": 1}) -> {a: {b: {c: 1}}}''', description = "Deep nested" },
+    { code = '''unflatten_keys({\"a\": 1, \"b\": 2}) -> {a: 1, b: 2}''', description = "Flat keys" },
+    { code = '''unflatten_keys({\"x.y\": 1, \"z\": 2}) -> {x: {y: 1}, z: 2}''', description = "Mixed nesting" },
 ]
 features = ["core"]
 

--- a/jmespath_extensions/src/object.rs
+++ b/jmespath_extensions/src/object.rs
@@ -33,7 +33,10 @@ pub fn register(runtime: &mut Runtime) {
     runtime.register_function("invert", Box::new(InvertFn::new()));
     runtime.register_function("rename_keys", Box::new(RenameKeysFn::new()));
     runtime.register_function("flatten_keys", Box::new(FlattenKeysFn::new()));
+    runtime.register_function("flatten", Box::new(FlattenKeysFn::new())); // alias
     runtime.register_function("unflatten_keys", Box::new(UnflattenKeysFn::new()));
+    runtime.register_function("unflatten", Box::new(UnflattenKeysFn::new())); // alias
+    runtime.register_function("flatten_array", Box::new(FlattenArrayFn::new()));
     runtime.register_function("deep_merge", Box::new(DeepMergeFn::new()));
     runtime.register_function("deep_equals", Box::new(DeepEqualsFn::new()));
     runtime.register_function("deep_diff", Box::new(DeepDiffFn::new()));
@@ -401,6 +404,87 @@ impl Function for UnflattenKeysFn {
             let parts: Vec<&str> = key.split(&separator).collect();
             insert_nested(&mut result, &parts, value.clone());
         }
+
+        Ok(Rc::new(Variable::Object(result)))
+    }
+}
+
+// =============================================================================
+// flatten_array(any, separator?) -> object
+// Flattens nested objects AND arrays with numeric indices
+// =============================================================================
+
+define_function!(
+    FlattenArrayFn,
+    vec![ArgumentType::Any],
+    Some(ArgumentType::String)
+);
+
+fn flatten_value(
+    value: &Variable,
+    prefix: &str,
+    separator: &str,
+    result: &mut BTreeMap<String, Rcvar>,
+) {
+    match value {
+        Variable::Object(obj) => {
+            if obj.is_empty() {
+                // Empty object is a leaf
+                if !prefix.is_empty() {
+                    result.insert(prefix.to_string(), Rc::new(Variable::Object(obj.clone())));
+                }
+            } else {
+                for (k, v) in obj.iter() {
+                    let new_key = if prefix.is_empty() {
+                        k.clone()
+                    } else {
+                        format!("{}{}{}", prefix, separator, k)
+                    };
+                    flatten_value(v, &new_key, separator, result);
+                }
+            }
+        }
+        Variable::Array(arr) => {
+            if arr.is_empty() {
+                // Empty array is a leaf
+                if !prefix.is_empty() {
+                    result.insert(prefix.to_string(), Rc::new(Variable::Array(arr.clone())));
+                }
+            } else {
+                for (idx, v) in arr.iter().enumerate() {
+                    let new_key = if prefix.is_empty() {
+                        idx.to_string()
+                    } else {
+                        format!("{}{}{}", prefix, separator, idx)
+                    };
+                    flatten_value(v, &new_key, separator, result);
+                }
+            }
+        }
+        _ => {
+            // Leaf value (string, number, bool, null)
+            if !prefix.is_empty() {
+                result.insert(prefix.to_string(), Rc::new(value.clone()));
+            } else {
+                // Top-level primitive - just return it as-is with empty key
+                result.insert(String::new(), Rc::new(value.clone()));
+            }
+        }
+    }
+}
+
+impl Function for FlattenArrayFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let default_sep = ".".to_string();
+        let separator = args
+            .get(1)
+            .and_then(|s| s.as_string().map(|s| s.to_string()))
+            .unwrap_or(default_sep);
+
+        let mut result: BTreeMap<String, Rcvar> = BTreeMap::new();
+        flatten_value(&args[0], "", &separator, &mut result);
 
         Ok(Rc::new(Variable::Object(result)))
     }


### PR DESCRIPTION
## Summary

This PR implements issue #203 - Object Flattening/Unflattening.

## Changes

### New Aliases
- `flatten()` - alias for `flatten_keys()`
- `unflatten()` - alias for `unflatten_keys()`

### New Function
- `flatten_array(value, separator?)` - flattens nested objects **and** arrays with numeric indices

### Documentation
- Added missing `unflatten_keys` to functions.toml
- Added all new functions (`flatten`, `unflatten`, `flatten_array`) to functions.toml

## Examples

```bash
# flatten alias
echo '{"a": {"b": 1}}' | jpx 'flatten(@)'
# {"a.b": 1}

# unflatten alias
echo '{"a.b": 1}' | jpx 'unflatten(@)'
# {"a": {"b": 1}}

# flatten_array - handles arrays with numeric indices
echo '{"a": [1, 2, 3]}' | jpx 'flatten_array(@)'
# {"a.0": 1, "a.1": 2, "a.2": 3}

# flatten_array with custom separator
echo '{"a": {"b": 1}}' | jpx 'flatten_array(@, "/")'
# {"a/b": 1}
```

Closes #203