### PR TITLE
feat(object): add data redaction/masking functions

### DIFF
--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -2748,6 +2748,41 @@ examples = [
 ]
 features = ["core"]
 
+[[functions]]
+name = "redact"
+category = "object"
+description = "Recursively replace values at specified keys with [REDACTED]"
+signature = "any, array -> any"
+examples = [
+    { code = '''redact({name: "alice", password: "secret"}, ["password"]) -> {name: "alice", password: "[REDACTED]"}''', description = "Redact password" },
+    { code = '''redact({user: {name: "bob", ssn: "123"}}, ["ssn"]) -> {user: {name: "bob", ssn: "[REDACTED]"}}''', description = "Nested redact" },
+    { code = '''redact([{token: "abc"}], ["token"]) -> [{token: "[REDACTED]"}]''', description = "Array of objects" },
+]
+features = ["core"]
+
+[[functions]]
+name = "mask"
+category = "object"
+description = "Mask a string, showing only the last N characters"
+signature = "string, number? -> string"
+examples = [
+    { code = '''mask("4111111111111111") -> "************1111"''', description = "Credit card default" },
+    { code = '''mask("555-123-4567", `3`) -> "*********567"''', description = "Phone with 3 visible" },
+    { code = '''mask("abc") -> "***"''', description = "Short string masked" },
+]
+features = ["core"]
+
+[[functions]]
+name = "redact_keys"
+category = "object"
+description = "Recursively redact keys matching a regex pattern"
+signature = "any, string -> any"
+examples = [
+    { code = '''redact_keys({password: "x", api_key: "y"}, "password|api_key") -> {password: "[REDACTED]", api_key: "[REDACTED]"}''', description = "Multiple patterns" },
+    { code = '''redact_keys({secret_key: "a", secret_token: "b"}, "secret.*") -> {secret_key: "[REDACTED]", secret_token: "[REDACTED]"}''', description = "Wildcard pattern" },
+]
+features = ["core"]
+
 # =============================================================================
 # PATH FUNCTIONS
 # =============================================================================

--- a/jmespath_extensions/src/object.rs
+++ b/jmespath_extensions/src/object.rs
@@ -60,6 +60,10 @@ pub fn register(runtime: &mut Runtime) {
     runtime.register_function("completeness", Box::new(CompletenessFn::new()));
     runtime.register_function("type_consistency", Box::new(TypeConsistencyFn::new()));
     runtime.register_function("data_quality_score", Box::new(DataQualityScoreFn::new()));
+    // Data redaction functions
+    runtime.register_function("redact", Box::new(RedactFn::new()));
+    runtime.register_function("mask", Box::new(MaskFn::new()));
+    runtime.register_function("redact_keys", Box::new(RedactKeysFn::new()));
 }
 
 // =============================================================================
@@ -1931,6 +1935,165 @@ fn analyze_quality(value: &Variable, path: String, stats: &mut QualityStats) {
     }
 }
 
+// =============================================================================
+// redact(any, keys) -> any (replace values at keys with [REDACTED])
+// =============================================================================
+
+define_function!(RedactFn, vec![ArgumentType::Any, ArgumentType::Array], None);
+
+impl Function for RedactFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let keys_arr = args[1].as_array().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected array of keys".to_owned()),
+            )
+        })?;
+
+        let keys: HashSet<String> = keys_arr
+            .iter()
+            .filter_map(|k| k.as_string().map(|s| s.to_string()))
+            .collect();
+
+        Ok(Rc::new(redact_recursive(&args[0], &keys)))
+    }
+}
+
+fn redact_recursive(value: &Variable, keys: &HashSet<String>) -> Variable {
+    match value {
+        Variable::Object(obj) => {
+            let redacted: BTreeMap<String, Rcvar> = obj
+                .iter()
+                .map(|(k, v)| {
+                    if keys.contains(k) {
+                        (
+                            k.clone(),
+                            Rc::new(Variable::String("[REDACTED]".to_string())),
+                        )
+                    } else {
+                        (k.clone(), Rc::new(redact_recursive(v, keys)))
+                    }
+                })
+                .collect();
+            Variable::Object(redacted)
+        }
+        Variable::Array(arr) => {
+            let redacted: Vec<Rcvar> = arr
+                .iter()
+                .map(|v| Rc::new(redact_recursive(v, keys)))
+                .collect();
+            Variable::Array(redacted)
+        }
+        _ => value.clone(),
+    }
+}
+
+// =============================================================================
+// mask(string, show_last?) -> string (mask all but last N chars)
+// =============================================================================
+
+define_function!(
+    MaskFn,
+    vec![ArgumentType::String],
+    Some(ArgumentType::Number)
+);
+
+impl Function for MaskFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let s = args[0].as_string().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected string argument".to_owned()),
+            )
+        })?;
+
+        let show_last = if args.len() > 1 {
+            args[1].as_number().unwrap_or(4.0) as usize
+        } else {
+            4
+        };
+
+        let len = s.len();
+        let masked = if len <= show_last {
+            "*".repeat(len)
+        } else {
+            let mask_count = len - show_last;
+            format!("{}{}", "*".repeat(mask_count), &s[mask_count..])
+        };
+
+        Ok(Rc::new(Variable::String(masked)))
+    }
+}
+
+// =============================================================================
+// redact_keys(any, pattern) -> any (redact keys matching pattern)
+// =============================================================================
+
+define_function!(
+    RedactKeysFn,
+    vec![ArgumentType::Any, ArgumentType::String],
+    None
+);
+
+impl Function for RedactKeysFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let pattern = args[1].as_string().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected pattern string".to_owned()),
+            )
+        })?;
+
+        let regex = regex::Regex::new(pattern).map_err(|e| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse(format!("Invalid regex pattern: {}", e)),
+            )
+        })?;
+
+        Ok(Rc::new(redact_keys_recursive(&args[0], &regex)))
+    }
+}
+
+fn redact_keys_recursive(value: &Variable, pattern: &regex::Regex) -> Variable {
+    match value {
+        Variable::Object(obj) => {
+            let redacted: BTreeMap<String, Rcvar> = obj
+                .iter()
+                .map(|(k, v)| {
+                    if pattern.is_match(k) {
+                        (
+                            k.clone(),
+                            Rc::new(Variable::String("[REDACTED]".to_string())),
+                        )
+                    } else {
+                        (k.clone(), Rc::new(redact_keys_recursive(v, pattern)))
+                    }
+                })
+                .collect();
+            Variable::Object(redacted)
+        }
+        Variable::Array(arr) => {
+            let redacted: Vec<Rcvar> = arr
+                .iter()
+                .map(|v| Rc::new(redact_keys_recursive(v, pattern)))
+                .collect();
+            Variable::Array(redacted)
+        }
+        _ => value.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2705,5 +2868,140 @@ mod tests {
                 .unwrap() as i64,
             1
         );
+    }
+
+    // =========================================================================
+    // redact tests
+    // =========================================================================
+
+    #[test]
+    fn test_redact_basic() {
+        let runtime = setup_runtime();
+        let data = Variable::from_json(
+            r#"{"name": "alice", "password": "secret123", "ssn": "123-45-6789"}"#,
+        )
+        .unwrap();
+        let expr = runtime
+            .compile(r#"redact(@, `["password", "ssn"]`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("name").unwrap().as_string().unwrap(), "alice");
+        assert_eq!(
+            obj.get("password").unwrap().as_string().unwrap(),
+            "[REDACTED]"
+        );
+        assert_eq!(obj.get("ssn").unwrap().as_string().unwrap(), "[REDACTED]");
+    }
+
+    #[test]
+    fn test_redact_nested() {
+        let runtime = setup_runtime();
+        let data =
+            Variable::from_json(r#"{"user": {"name": "bob", "password": "secret"}}"#).unwrap();
+        let expr = runtime.compile(r#"redact(@, `["password"]`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let user = obj.get("user").unwrap().as_object().unwrap();
+        assert_eq!(user.get("name").unwrap().as_string().unwrap(), "bob");
+        assert_eq!(
+            user.get("password").unwrap().as_string().unwrap(),
+            "[REDACTED]"
+        );
+    }
+
+    #[test]
+    fn test_redact_array_of_objects() {
+        let runtime = setup_runtime();
+        let data = Variable::from_json(
+            r#"[{"name": "alice", "token": "abc"}, {"name": "bob", "token": "xyz"}]"#,
+        )
+        .unwrap();
+        let expr = runtime.compile(r#"redact(@, `["token"]`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        let first = arr[0].as_object().unwrap();
+        assert_eq!(
+            first.get("token").unwrap().as_string().unwrap(),
+            "[REDACTED]"
+        );
+    }
+
+    // =========================================================================
+    // mask tests
+    // =========================================================================
+
+    #[test]
+    fn test_mask_default() {
+        let runtime = setup_runtime();
+        let data = Variable::String("4111111111111111".to_string());
+        let expr = runtime.compile("mask(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "************1111");
+    }
+
+    #[test]
+    fn test_mask_custom_length() {
+        let runtime = setup_runtime();
+        let data = Variable::String("555-123-4567".to_string());
+        let expr = runtime.compile("mask(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_string().unwrap(), "*********567");
+    }
+
+    #[test]
+    fn test_mask_short_string() {
+        let runtime = setup_runtime();
+        let data = Variable::String("abc".to_string());
+        let expr = runtime.compile("mask(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // If string is shorter than show_last, mask everything
+        assert_eq!(result.as_string().unwrap(), "***");
+    }
+
+    // =========================================================================
+    // redact_keys tests
+    // =========================================================================
+
+    #[test]
+    fn test_redact_keys_basic() {
+        let runtime = setup_runtime();
+        let data =
+            Variable::from_json(r#"{"password": "secret", "api_key": "abc123", "name": "test"}"#)
+                .unwrap();
+        let expr = runtime
+            .compile(r#"redact_keys(@, `"password|api_key"`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(
+            obj.get("password").unwrap().as_string().unwrap(),
+            "[REDACTED]"
+        );
+        assert_eq!(
+            obj.get("api_key").unwrap().as_string().unwrap(),
+            "[REDACTED]"
+        );
+        assert_eq!(obj.get("name").unwrap().as_string().unwrap(), "test");
+    }
+
+    #[test]
+    fn test_redact_keys_pattern() {
+        let runtime = setup_runtime();
+        let data =
+            Variable::from_json(r#"{"secret_key": "a", "secret_token": "b", "name": "test"}"#)
+                .unwrap();
+        let expr = runtime.compile(r#"redact_keys(@, `"secret.*"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(
+            obj.get("secret_key").unwrap().as_string().unwrap(),
+            "[REDACTED]"
+        );
+        assert_eq!(
+            obj.get("secret_token").unwrap().as_string().unwrap(),
+            "[REDACTED]"
+        );
+        assert_eq!(obj.get("name").unwrap().as_string().unwrap(), "test");
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #207 - data redaction/masking functions.

## New Functions

| Function | Signature | Description |
|----------|-----------|-------------|
| `redact(any, keys)` | `any, array -> any` | Recursively replace values at specified keys with [REDACTED] |
| `mask(string, show_last?)` | `string, number? -> string` | Mask string showing only last N chars (default 4) |
| `redact_keys(any, pattern)` | `any, string -> any` | Redact keys matching regex pattern |

## Examples

```bash
# Redact specific keys
echo '{"name": "alice", "password": "secret", "api_key": "xyz"}' | jpx 'redact(@, [`"password"`, `"api_key"`])'
# {"name": "alice", "password": "[REDACTED]", "api_key": "[REDACTED]"}

# Mask credit card (show last 4)
echo '"4111111111111111"' | jpx 'mask(@)'
# "************1111"

# Mask phone number (show last 3)
echo '"555-123-4567"' | jpx 'mask(@, `3`)'
# "*********567"

# Redact by pattern
echo '{"secret_key": "a", "secret_token": "b", "name": "test"}' | jpx 'redact_keys(@, `"secret.*"`)'
# {"secret_key": "[REDACTED]", "secret_token": "[REDACTED]", "name": "test"}
```

## Use Cases

- Sanitizing logs before storage
- GDPR/CCPA compliance in data exports
- Sharing API responses without exposing secrets
- Preparing data for debugging/support
- Audit trail sanitization

Closes #207