### PR TITLE
ci: add Python release workflow for PyPI publishing

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,0 +1,101 @@
+name: Python Release
+
+on:
+  push:
+    tags:
+      - "py-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 0.1.0)"
+        required: true
+
+env:
+  PACKAGE_NAME: jmespath-extensions
+
+jobs:
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install maturin
+        run: pip install maturin
+      - name: Build sdist
+        working-directory: jmespath-extensions-py
+        run: maturin sdist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: jmespath-extensions-py/target/wheels/*.tar.gz
+
+  build-wheels:
+    name: Build wheels (${{ matrix.os }} ${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64
+          - os: ubuntu-latest
+            target: x86_64
+            manylinux: auto
+          # Linux aarch64
+          - os: ubuntu-latest
+            target: aarch64
+            manylinux: auto
+          # macOS x86_64
+          - os: macos-13
+            target: x86_64
+            manylinux: auto
+          # macOS arm64
+          - os: macos-latest
+            target: aarch64
+            manylinux: auto
+          # Windows x86_64
+          - os: windows-latest
+            target: x86_64
+            manylinux: auto
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: jmespath-extensions-py
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          args: --release --out dist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
+          path: jmespath-extensions-py/dist/*.whl
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-sdist, build-wheels]
+    environment:
+      name: pypi
+      url: https://pypi.org/project/jmespath-extensions/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: List artifacts
+        run: ls -la dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
Adds a GitHub Actions workflow for publishing the Python package to PyPI.

## Workflow: `python-release.yml`

### Triggers
- Push tags matching `py-v*` (e.g., `py-v0.1.0`)
- Manual workflow dispatch with version input

### Build Matrix
- **Source distribution** (sdist)
- **Linux**: x86_64 and aarch64 (manylinux)
- **macOS**: x86_64 (Intel) and arm64 (Apple Silicon)
- **Windows**: x86_64

### Publishing
Uses PyPI trusted publishing (OIDC) - no API tokens needed.

### Usage
To release version 0.1.0:
```bash
git tag py-v0.1.0
git push origin py-v0.1.0
```

Or trigger manually via GitHub Actions UI.

## Prerequisites
The PyPI project `jmespath-extensions` needs trusted publisher configured:
- Owner: `joshrotenberg`
- Repository: `jmespath-extensions`
- Workflow: `python-release.yml`
- Environment: `pypi`