### PR TITLE
fix: exclude Python crate from release-plz and crates.io

### DIFF
--- a/jmespath-extensions-py/Cargo.toml
+++ b/jmespath-extensions-py/Cargo.toml
@@ -10,6 +10,8 @@ description = "Python bindings for jmespath-extensions - 320+ functions for JMES
 readme = "README.md"
 keywords = ["jmespath", "json", "query", "python", "pyo3"]
 categories = ["api-bindings"]
+# This crate is not published to crates.io - it's a Python package published to PyPI
+publish = false
 
 [lib]
 name = "jmespath_extensions_py"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,3 +20,9 @@ name = "jpx"
 publish = true
 git_release_enable = false
 git_tag_name = "jpx-v{{ version }}"
+
+# Python bindings - excluded from release-plz, uses separate python-release workflow
+[[package]]
+name = "jmespath-extensions-py"
+release = false
+publish = false


### PR DESCRIPTION
Fixes the release-plz error when trying to publish the Python crate to crates.io.

## Problem
```
failed to publish jmespath-extensions-py: error: failed to verify manifest
  all dependencies must have a version requirement specified when publishing.
  dependency `jmespath_extensions` does not specify a version
```

## Solution
The Python crate should not be published to crates.io - it's a Python package published to PyPI via the `python-release.yml` workflow.

### Changes
1. **jmespath-extensions-py/Cargo.toml**: Add `publish = false`
2. **release-plz.toml**: Add config to skip the Python crate:
   ```toml
   [[package]]
   name = "jmespath-extensions-py"
   release = false
   publish = false
   ```