### PR TITLE
docs: add mdbook documentation site with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/book/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
+
+      - name: Build book
+        run: mdbook build docs/book
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book/build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,0 +1,20 @@
+[book]
+title = "jpx - JMESPath Extended"
+authors = ["Josh Rotenberg"]
+description = "JMESPath CLI with 320+ extension functions"
+language = "en"
+src = "src"
+
+[build]
+build-dir = "build"
+
+[output.html]
+default-theme = "rust"
+preferred-dark-theme = "ayu"
+git-repository-url = "https://github.com/joshrotenberg/jmespath-extensions"
+edit-url-template = "https://github.com/joshrotenberg/jmespath-extensions/edit/main/docs/book/{path}"
+site-url = "/jmespath-extensions/"
+
+[output.html.search]
+enable = true
+limit-results = 30

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,0 +1,51 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+# Getting Started
+
+- [Installation](./getting-started/installation.md)
+- [Quick Start](./getting-started/quick-start.md)
+- [Basic Usage](./getting-started/basic-usage.md)
+
+# User Guide
+
+- [CLI Reference](./guide/cli-reference.md)
+- [Expression Syntax](./guide/expression-syntax.md)
+- [Working with Files](./guide/working-with-files.md)
+- [Query Files](./guide/query-files.md)
+- [Strict Mode](./guide/strict-mode.md)
+
+# MCP Server
+
+- [Overview](./mcp/overview.md)
+- [Setup with Claude](./mcp/setup-claude.md)
+- [Available Tools](./mcp/tools.md)
+- [Examples](./mcp/examples.md)
+
+# Function Reference
+
+- [Overview](./functions/overview.md)
+- [Standard Functions](./functions/standard.md)
+- [String Functions](./functions/string.md)
+- [Array Functions](./functions/array.md)
+- [Object Functions](./functions/object.md)
+- [Math Functions](./functions/math.md)
+- [Date/Time Functions](./functions/datetime.md)
+- [Hash & Encoding](./functions/hash-encoding.md)
+- [Validation Functions](./functions/validation.md)
+- [Expression Functions](./functions/expression.md)
+- [Other Functions](./functions/other.md)
+
+# Python Bindings
+
+- [Installation](./python/installation.md)
+- [Usage](./python/usage.md)
+- [API Reference](./python/api.md)
+
+# Examples
+
+- [Data Transformation](./examples/data-transformation.md)
+- [Log Processing](./examples/log-processing.md)
+- [API Response Handling](./examples/api-responses.md)
+- [jq Comparison](./examples/jq-comparison.md)

--- a/docs/book/src/examples/api-responses.md
+++ b/docs/book/src/examples/api-responses.md
@@ -1,0 +1,4 @@
+# api responses
+
+Coming soon.
+

--- a/docs/book/src/examples/data-transformation.md
+++ b/docs/book/src/examples/data-transformation.md
@@ -1,0 +1,4 @@
+# data transformation
+
+Coming soon.
+

--- a/docs/book/src/examples/jq-comparison.md
+++ b/docs/book/src/examples/jq-comparison.md
@@ -1,0 +1,4 @@
+# jq comparison
+
+Coming soon.
+

--- a/docs/book/src/examples/log-processing.md
+++ b/docs/book/src/examples/log-processing.md
@@ -1,0 +1,4 @@
+# log processing
+
+Coming soon.
+

--- a/docs/book/src/functions/array.md
+++ b/docs/book/src/functions/array.md
@@ -1,0 +1,4 @@
+# array
+
+Coming soon.
+

--- a/docs/book/src/functions/datetime.md
+++ b/docs/book/src/functions/datetime.md
@@ -1,0 +1,4 @@
+# datetime
+
+Coming soon.
+

--- a/docs/book/src/functions/expression.md
+++ b/docs/book/src/functions/expression.md
@@ -1,0 +1,4 @@
+# expression
+
+Coming soon.
+

--- a/docs/book/src/functions/hash-encoding.md
+++ b/docs/book/src/functions/hash-encoding.md
@@ -1,0 +1,4 @@
+# hash encoding
+
+Coming soon.
+

--- a/docs/book/src/functions/math.md
+++ b/docs/book/src/functions/math.md
@@ -1,0 +1,4 @@
+# math
+
+Coming soon.
+

--- a/docs/book/src/functions/object.md
+++ b/docs/book/src/functions/object.md
@@ -1,0 +1,4 @@
+# ouject
+
+Coming soon.
+

--- a/docs/book/src/functions/other.md
+++ b/docs/book/src/functions/other.md
@@ -1,0 +1,4 @@
+# other
+
+Coming soon.
+

--- a/docs/book/src/functions/overview.md
+++ b/docs/book/src/functions/overview.md
@@ -1,0 +1,99 @@
+# Function Overview
+
+jpx provides over 320 functions organized into categories.
+
+## Discovering Functions
+
+### List All Functions
+
+```bash
+jpx --list-functions
+```
+
+### List by Category
+
+```bash
+jpx --list-category string
+jpx --list-category math
+jpx --list-category datetime
+```
+
+### Get Function Details
+
+```bash
+jpx --describe upper
+```
+
+Output:
+```
+STRING functions:
+
+  upper - Convert string to uppercase
+    Signature: string -> string
+    Example: upper('hello') -> "HELLO"
+```
+
+## Categories
+
+| Category | Description | Count |
+|----------|-------------|-------|
+| [Standard](./standard.md) | Built-in JMESPath functions | 26 |
+| [String](./string.md) | String manipulation | 40+ |
+| [Array](./array.md) | Array operations | 30+ |
+| [Object](./object.md) | Object manipulation | 25+ |
+| [Math](./math.md) | Math and statistics | 30+ |
+| [DateTime](./datetime.md) | Date and time | 15+ |
+| [Hash & Encoding](./hash-encoding.md) | Hashing and encoding | 20+ |
+| [Validation](./validation.md) | Data validation | 10+ |
+| [Expression](./expression.md) | Higher-order functions | 10+ |
+| [Other](./other.md) | Geo, fuzzy, network, etc. | 100+ |
+
+## Function Syntax
+
+Functions are called with parentheses:
+
+```bash
+function_name(arg1, arg2, ...)
+```
+
+### Examples
+
+```bash
+# No arguments
+echo '{}' | jpx 'now()'
+
+# One argument
+echo '{"name": "hello"}' | jpx 'upper(name)'
+
+# Multiple arguments
+echo '{"text": "hello world"}' | jpx 'split(text, ` `)'
+
+# Literal arguments (use backticks)
+echo '{}' | jpx 'range(`1`, `10`)'
+```
+
+## Standard vs Extension Functions
+
+### Standard Functions (26)
+
+These are part of the JMESPath specification and work in all implementations:
+
+`abs`, `avg`, `ceil`, `contains`, `ends_with`, `floor`, `join`, `keys`, `length`, `map`, `max`, `max_by`, `merge`, `min`, `min_by`, `not_null`, `reverse`, `sort`, `sort_by`, `starts_with`, `sum`, `to_array`, `to_number`, `to_string`, `type`, `values`
+
+### Extension Functions (300+)
+
+These are jpx-specific and won't work in other JMESPath implementations:
+
+`upper`, `lower`, `split`, `unique`, `chunk`, `median`, `now`, `uuid`, `md5`, and many more.
+
+### Strict Mode
+
+Use `--strict` to disable extension functions:
+
+```bash
+# This works
+jpx --strict 'length(items)' -f data.json
+
+# This fails (upper is an extension)
+jpx --strict 'upper(name)' -f data.json
+```

--- a/docs/book/src/functions/standard.md
+++ b/docs/book/src/functions/standard.md
@@ -1,0 +1,4 @@
+# standard
+
+Coming soon.
+

--- a/docs/book/src/functions/string.md
+++ b/docs/book/src/functions/string.md
@@ -1,0 +1,4 @@
+# string
+
+Coming soon.
+

--- a/docs/book/src/functions/validation.md
+++ b/docs/book/src/functions/validation.md
@@ -1,0 +1,4 @@
+# validation
+
+Coming soon.
+

--- a/docs/book/src/getting-started/basic-usage.md
+++ b/docs/book/src/getting-started/basic-usage.md
@@ -1,0 +1,145 @@
+# Basic Usage
+
+## Input Sources
+
+jpx can read JSON from multiple sources:
+
+### Standard Input (stdin)
+
+```bash
+echo '{"name": "Alice"}' | jpx 'name'
+cat data.json | jpx 'users[*].name'
+curl -s https://api.example.com/data | jpx 'results[0]'
+```
+
+### File Input
+
+```bash
+jpx 'users[*].name' -f data.json
+jpx --file users.json 'length(@)'
+```
+
+### Null Input
+
+Use `-n` to start with null (useful for functions that don't need input):
+
+```bash
+jpx -n 'now()'
+jpx -n 'uuid()'
+jpx -n 'range(`1`, `10`)'
+```
+
+## Output Options
+
+### Pretty Printing (default)
+
+By default, jpx pretty-prints JSON output with colors:
+
+```bash
+echo '{"a":1,"b":2}' | jpx '@'
+```
+
+Output:
+```json
+{
+  "a": 1,
+  "b": 2
+}
+```
+
+### Compact Output
+
+Use `-c` for single-line output:
+
+```bash
+echo '{"a":1,"b":2}' | jpx -c '@'
+```
+
+Output:
+```json
+{"a":1,"b":2}
+```
+
+### Raw Strings
+
+Use `-r` to output strings without quotes:
+
+```bash
+echo '{"msg": "hello"}' | jpx -r 'msg'
+```
+
+Output:
+```
+hello
+```
+
+### Output to File
+
+Write results to a file:
+
+```bash
+jpx 'users[*].email' -f data.json -o emails.json
+```
+
+## Slurp Mode
+
+Read multiple JSON objects into an array:
+
+```bash
+echo '{"a":1}
+{"b":2}
+{"c":3}' | jpx -s 'length(@)'
+```
+
+Output:
+```
+3
+```
+
+## Expression as Positional Argument
+
+The expression can be the first positional argument:
+
+```bash
+jpx 'users[*].name' -f data.json
+```
+
+Or use `-e` / `--expression`:
+
+```bash
+jpx -e 'users[*].name' -f data.json
+```
+
+## Chaining Expressions
+
+Chain multiple expressions (applied sequentially):
+
+```bash
+jpx -e 'users' -e '[*].name' -e 'sort(@)' -f data.json
+```
+
+## Verbose Mode
+
+See expression details and timing:
+
+```bash
+echo '{"x": 1}' | jpx -v 'x'
+```
+
+## Quiet Mode
+
+Suppress errors and warnings:
+
+```bash
+jpx -q 'invalid[' -f data.json  # Won't show error output
+```
+
+## Color Control
+
+Control colorized output:
+
+```bash
+jpx --color=always 'name' -f data.json  # Force colors
+jpx --color=never 'name' -f data.json   # No colors
+jpx --color=auto 'name' -f data.json    # Auto-detect (default)
+```

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -1,0 +1,77 @@
+# Installation
+
+## Homebrew (macOS/Linux)
+
+The easiest way to install jpx on macOS or Linux:
+
+```bash
+brew tap joshrotenberg/brew
+brew install jpx
+```
+
+## Pre-built Binaries
+
+Download pre-built binaries for your platform from the [GitHub Releases](https://github.com/joshrotenberg/jmespath-extensions/releases) page.
+
+Available platforms:
+- macOS (Apple Silicon / arm64)
+- macOS (Intel / x86_64)
+- Linux (x86_64)
+- Windows (x86_64)
+
+## Cargo (from crates.io)
+
+If you have Rust installed:
+
+```bash
+cargo install jpx
+```
+
+## From Source
+
+Clone and build from source:
+
+```bash
+git clone https://github.com/joshrotenberg/jmespath-extensions
+cd jmespath-extensions/jpx
+cargo install --path .
+```
+
+### With MCP Server Support
+
+To include the MCP server for AI assistant integration:
+
+```bash
+cargo install --path . --features mcp
+```
+
+## Verify Installation
+
+Check that jpx is installed correctly:
+
+```bash
+jpx --version
+```
+
+You should see output like:
+```
+jpx 0.1.15
+```
+
+## Shell Completions
+
+Generate shell completions for your shell:
+
+```bash
+# Bash
+jpx --completions bash > ~/.local/share/bash-completion/completions/jpx
+
+# Zsh
+jpx --completions zsh > ~/.zfunc/_jpx
+
+# Fish
+jpx --completions fish > ~/.config/fish/completions/jpx.fish
+
+# PowerShell
+jpx --completions powershell > jpx.ps1
+```

--- a/docs/book/src/getting-started/quick-start.md
+++ b/docs/book/src/getting-started/quick-start.md
@@ -1,0 +1,115 @@
+# Quick Start
+
+This guide will get you up and running with jpx in just a few minutes.
+
+## Your First Query
+
+Let's start with a simple JSON object:
+
+```bash
+echo '{"name": "Alice", "age": 30}' | jpx 'name'
+```
+
+Output:
+```
+"Alice"
+```
+
+## Querying Arrays
+
+Access array elements and properties:
+
+```bash
+echo '{"users": [{"name": "Alice"}, {"name": "Bob"}]}' | jpx 'users[0].name'
+```
+
+Output:
+```
+"Alice"
+```
+
+Get all names:
+
+```bash
+echo '{"users": [{"name": "Alice"}, {"name": "Bob"}]}' | jpx 'users[*].name'
+```
+
+Output:
+```
+["Alice", "Bob"]
+```
+
+## Using Extension Functions
+
+Here's where jpx shines. Use any of the 320+ extension functions:
+
+```bash
+# String manipulation
+echo '{"name": "hello world"}' | jpx 'upper(name)'
+# "HELLO WORLD"
+
+# Array operations
+echo '{"nums": [3, 1, 4, 1, 5, 9, 2, 6]}' | jpx 'unique(nums) | sort(@)'
+# [1, 2, 3, 4, 5, 6, 9]
+
+# Math functions
+echo '{"values": [10, 20, 30, 40, 50]}' | jpx 'avg(values)'
+# 30
+
+# Current timestamp
+echo '{}' | jpx 'now()'
+# 1705312200
+```
+
+## Raw Output
+
+Use `-r` to output strings without quotes:
+
+```bash
+echo '{"greeting": "Hello, World!"}' | jpx -r 'greeting'
+```
+
+Output:
+```
+Hello, World!
+```
+
+## Reading from Files
+
+Query a JSON file directly:
+
+```bash
+jpx 'users[*].email' -f data.json
+```
+
+## Piping and Chaining
+
+Chain multiple expressions with the pipe operator:
+
+```bash
+echo '{"items": ["apple", "banana", "cherry"]}' | jpx 'items | [0]'
+# "apple"
+
+echo '{"name": "john doe"}' | jpx 'name | upper(@) | split(@, ` `)'
+# ["JOHN", "DOE"]
+```
+
+## Function Discovery
+
+Find functions by category:
+
+```bash
+jpx --list-category string
+```
+
+Get details about a specific function:
+
+```bash
+jpx --describe upper
+```
+
+## Next Steps
+
+- [Basic Usage](./basic-usage.md) - Learn more CLI options
+- [CLI Reference](../guide/cli-reference.md) - Complete CLI documentation
+- [Function Reference](../functions/overview.md) - Browse all 320+ functions

--- a/docs/book/src/guide/cli-reference.md
+++ b/docs/book/src/guide/cli-reference.md
@@ -1,0 +1,110 @@
+# CLI Reference
+
+Complete reference for all jpx command-line options.
+
+## Synopsis
+
+```
+jpx [OPTIONS] [EXPRESSION]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `[EXPRESSION]` | JMESPath expression to evaluate (positional) |
+
+## Options
+
+### Input/Output
+
+| Option | Description |
+|--------|-------------|
+| `-e, --expression <EXPR>` | Expression(s) to evaluate (can be repeated) |
+| `-Q, --query-file <FILE>` | Read JMESPath expression from file |
+| `-f, --file <FILE>` | Input JSON file (reads stdin if not provided) |
+| `-o, --output <FILE>` | Output file (writes to stdout if not provided) |
+| `-n, --null-input` | Don't read input, use null as input value |
+| `-s, --slurp` | Read all inputs into an array |
+
+### Output Format
+
+| Option | Description |
+|--------|-------------|
+| `-r, --raw` | Output raw strings without quotes |
+| `-c, --compact` | Compact output (no pretty printing) |
+| `--color <MODE>` | Colorize output: `auto`, `always`, `never` |
+
+### Modes
+
+| Option | Description |
+|--------|-------------|
+| `--strict` | Strict mode - only standard JMESPath functions |
+| `-v, --verbose` | Show expression details and timing |
+| `-q, --quiet` | Suppress errors and warnings |
+
+### Function Discovery
+
+| Option | Description |
+|--------|-------------|
+| `--list-functions` | List all available functions |
+| `--list-category <NAME>` | List functions in a specific category |
+| `--describe <FUNCTION>` | Show detailed info for a function |
+
+### Other
+
+| Option | Description |
+|--------|-------------|
+| `--completions <SHELL>` | Generate shell completions |
+| `-h, --help` | Print help |
+| `-V, --version` | Print version |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `JPX_VERBOSE=1` | Enable verbose mode |
+| `JPX_QUIET=1` | Enable quiet mode |
+| `JPX_STRICT=1` | Enable strict mode |
+| `JPX_RAW=1` | Output raw strings |
+| `JPX_COMPACT=1` | Compact output |
+
+Environment variables are overridden by command-line flags.
+
+## Examples
+
+```bash
+# Basic query from stdin
+echo '{"name": "Alice"}' | jpx 'name'
+
+# Query a file
+jpx 'users[*].email' -f data.json
+
+# Raw output for scripting
+jpx -r 'config.api_key' -f settings.json
+
+# Chain multiple expressions
+jpx -e 'users' -e '[?active]' -e '[*].name' -f data.json
+
+# Use null input for functions that don't need data
+jpx -n 'now()'
+
+# Slurp multiple JSON objects
+cat *.json | jpx -s 'length(@)'
+
+# List string functions
+jpx --list-category string
+
+# Get function documentation
+jpx --describe median
+
+# Strict mode (standard JMESPath only)
+jpx --strict 'length(items)' -f data.json
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (invalid expression, file not found, etc.) |

--- a/docs/book/src/guide/expression-syntax.md
+++ b/docs/book/src/guide/expression-syntax.md
@@ -1,0 +1,172 @@
+# Expression Syntax
+
+JMESPath expression syntax reference.
+
+## Identifiers
+
+Access object properties by name:
+
+```bash
+echo '{"name": "Alice", "age": 30}' | jpx 'name'
+# "Alice"
+```
+
+## Index Expressions
+
+Access array elements by index (0-based):
+
+```bash
+echo '{"items": ["a", "b", "c"]}' | jpx 'items[0]'
+# "a"
+
+echo '{"items": ["a", "b", "c"]}' | jpx 'items[-1]'
+# "c"
+```
+
+## Slicing
+
+Extract array slices with `[start:stop:step]`:
+
+```bash
+echo '[0, 1, 2, 3, 4, 5]' | jpx '[0:3]'
+# [0, 1, 2]
+
+echo '[0, 1, 2, 3, 4, 5]' | jpx '[::2]'
+# [0, 2, 4]
+
+echo '[0, 1, 2, 3, 4, 5]' | jpx '[::-1]'
+# [5, 4, 3, 2, 1, 0]
+```
+
+## Wildcard
+
+Project all elements with `*`:
+
+```bash
+echo '{"users": [{"name": "Alice"}, {"name": "Bob"}]}' | jpx 'users[*].name'
+# ["Alice", "Bob"]
+```
+
+## Flatten
+
+Flatten nested arrays with `[]`:
+
+```bash
+echo '[[1, 2], [3, 4]]' | jpx '[]'
+# [1, 2, 3, 4]
+```
+
+## Filter Expressions
+
+Filter arrays with `[?expression]`:
+
+```bash
+echo '[{"age": 25}, {"age": 17}, {"age": 30}]' | jpx '[?age > `18`]'
+# [{"age": 25}, {"age": 30}]
+
+echo '[{"name": "Alice", "active": true}, {"name": "Bob", "active": false}]' | jpx '[?active].name'
+# ["Alice"]
+```
+
+### Comparison Operators
+
+| Operator | Description |
+|----------|-------------|
+| `==` | Equal |
+| `!=` | Not equal |
+| `<` | Less than |
+| `<=` | Less than or equal |
+| `>` | Greater than |
+| `>=` | Greater than or equal |
+
+### Logical Operators
+
+| Operator | Description |
+|----------|-------------|
+| `&&` | Logical AND |
+| `\|\|` | Logical OR |
+| `!` | Logical NOT |
+
+## Pipe Expressions
+
+Chain expressions with `|`:
+
+```bash
+echo '{"items": [3, 1, 2]}' | jpx 'items | sort(@) | reverse(@)'
+# [3, 2, 1]
+```
+
+## Multi-Select List
+
+Create arrays from multiple expressions:
+
+```bash
+echo '{"a": 1, "b": 2, "c": 3}' | jpx '[a, b]'
+# [1, 2]
+```
+
+## Multi-Select Hash
+
+Create objects from multiple expressions:
+
+```bash
+echo '{"first": "Alice", "last": "Smith", "age": 30}' | jpx '{name: first, surname: last}'
+# {"name": "Alice", "surname": "Smith"}
+```
+
+## Literal Values
+
+Use backticks for literal values:
+
+```bash
+# Literal number
+echo '{"items": [1, 2, 3]}' | jpx '[?@ > `1`]'
+
+# Literal string
+echo '{"items": ["a", "b"]}' | jpx 'contains(items, `"a"`)'
+
+# Literal array
+echo '{}' | jpx '`[1, 2, 3]`'
+
+# Literal object
+echo '{}' | jpx '`{"key": "value"}`'
+```
+
+## Current Node
+
+Reference the current node with `@`:
+
+```bash
+echo '[1, 2, 3, 4, 5]' | jpx '[?@ > `2`]'
+# [3, 4, 5]
+
+echo '"hello"' | jpx 'upper(@)'
+# "HELLO"
+```
+
+## Function Calls
+
+Call functions with `function_name(arg1, arg2, ...)`:
+
+```bash
+echo '{"items": [1, 2, 3]}' | jpx 'length(items)'
+# 3
+
+echo '{"name": "hello"}' | jpx 'upper(name)'
+# "HELLO"
+
+echo '{"a": [1, 2], "b": [3, 4]}' | jpx 'merge(a, b)'
+# [1, 2, 3, 4]
+```
+
+## Expression References
+
+Use `&` for expression references (used with higher-order functions):
+
+```bash
+echo '[{"age": 30}, {"age": 20}]' | jpx 'sort_by(@, &age)'
+# [{"age": 20}, {"age": 30}]
+
+echo '[1, 2, 3]' | jpx 'map(&@ * `2`, @)'
+# [2, 4, 6]
+```

--- a/docs/book/src/guide/query-files.md
+++ b/docs/book/src/guide/query-files.md
@@ -1,0 +1,4 @@
+# query files
+
+Coming soon.
+

--- a/docs/book/src/guide/strict-mode.md
+++ b/docs/book/src/guide/strict-mode.md
@@ -1,0 +1,4 @@
+# strict mode
+
+Coming soon.
+

--- a/docs/book/src/guide/working-with-files.md
+++ b/docs/book/src/guide/working-with-files.md
@@ -1,0 +1,4 @@
+# working with files
+
+Coming soon.
+

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,0 +1,50 @@
+# Introduction
+
+**jpx** is a powerful command-line tool for querying and transforming JSON data using JMESPath expressions, extended with over 320 additional functions.
+
+## What is JMESPath?
+
+[JMESPath](https://jmespath.org/) is a query language for JSON. It allows you to declaratively specify how to extract and transform elements from a JSON document.
+
+## Why jpx?
+
+While standard JMESPath is powerful, it's intentionally minimal with only 26 built-in functions. jpx extends JMESPath with 320+ additional functions for:
+
+- **String manipulation**: `upper`, `lower`, `split`, `replace`, `camel_case`, `snake_case`, and more
+- **Array operations**: `unique`, `chunk`, `flatten`, `group_by`, `zip`, and more
+- **Object manipulation**: `pick`, `omit`, `deep_merge`, `flatten_keys`, and more
+- **Math & statistics**: `round`, `sqrt`, `median`, `stddev`, `percentile`, and more
+- **Date/time**: `now`, `format_date`, `parse_date`, `date_add`, `date_diff`
+- **Hashing & encoding**: `md5`, `sha256`, `base64_encode`, `hex_encode`
+- **Fuzzy matching**: `levenshtein`, `jaro_winkler`, `soundex`
+- **And much more**: geo functions, validation, regex, UUIDs, network utilities...
+
+## Features
+
+- **Powerful CLI**: Query JSON from files, stdin, or inline
+- **MCP Server**: Use jpx with AI assistants like Claude
+- **Python Bindings**: Use the same 320+ functions in Python
+- **Function Discovery**: Built-in help for all functions
+- **Strict Mode**: Use only standard JMESPath for portable queries
+
+## Quick Example
+
+```bash
+# Basic query
+echo '{"users": [{"name": "alice"}, {"name": "bob"}]}' | jpx 'users[*].name'
+# ["alice", "bob"]
+
+# Using extension functions
+echo '{"name": "hello world"}' | jpx 'upper(name)'
+# "HELLO WORLD"
+
+echo '{"items": [1, 2, 2, 3, 3, 3]}' | jpx 'unique(items)'
+# [1, 2, 3]
+
+echo '{"values": [10, 20, 30, 40, 50]}' | jpx 'median(values)'
+# 30
+```
+
+## Getting Started
+
+Ready to dive in? Start with [Installation](./getting-started/installation.md) to get jpx set up on your system.

--- a/docs/book/src/mcp/examples.md
+++ b/docs/book/src/mcp/examples.md
@@ -1,0 +1,4 @@
+# examples
+
+Coming soon.
+

--- a/docs/book/src/mcp/overview.md
+++ b/docs/book/src/mcp/overview.md
@@ -1,0 +1,44 @@
+# MCP Server Overview
+
+jpx can run as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server, allowing AI assistants like Claude to use JMESPath for JSON querying and transformation.
+
+## What is MCP?
+
+MCP is an open protocol that enables AI assistants to interact with external tools and data sources. By running jpx as an MCP server, you give Claude (and other MCP-compatible assistants) the ability to:
+
+- Query JSON data using JMESPath expressions
+- Transform and manipulate JSON structures
+- Use all 320+ extension functions
+- Explore available functions and their documentation
+
+## Why Use jpx with Claude?
+
+When working with JSON data in Claude, jpx provides:
+
+- **Precise queries**: Extract exactly the data you need
+- **Complex transformations**: Reshape data structures on the fly
+- **Powerful functions**: String manipulation, math, dates, hashing, and more
+- **Consistent results**: Deterministic query execution
+
+## Available Tools
+
+The MCP server exposes 12 tools:
+
+| Tool | Description |
+|------|-------------|
+| `evaluate` | Run JMESPath expressions against JSON input |
+| `evaluate_file` | Query JSON files directly from disk |
+| `batch_evaluate` | Run multiple expressions against the same input |
+| `format` | Pretty-print JSON with configurable indentation |
+| `diff` | Generate RFC 6902 JSON Patch between documents |
+| `patch` | Apply RFC 6902 JSON Patch operations |
+| `merge` | Apply RFC 7396 JSON Merge Patch |
+| `keys` | Extract object keys (optionally recursive) |
+| `functions` | List available functions |
+| `describe` | Get detailed info for a specific function |
+| `categories` | List all function categories |
+| `validate` | Check expression syntax without executing |
+
+## Getting Started
+
+See [Setup with Claude](./setup-claude.md) to configure jpx as an MCP server for Claude Desktop.

--- a/docs/book/src/mcp/setup-claude.md
+++ b/docs/book/src/mcp/setup-claude.md
@@ -1,0 +1,104 @@
+# Setup with Claude Desktop
+
+Configure jpx as an MCP server for Claude Desktop.
+
+## Prerequisites
+
+1. Install jpx with MCP support:
+   ```bash
+   brew install joshrotenberg/brew/jpx
+   # or
+   cargo install jpx --features mcp
+   ```
+
+2. Have Claude Desktop installed
+
+## Configuration
+
+### macOS
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "jpx",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+If jpx is not in your PATH, use the full path:
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "/opt/homebrew/bin/jpx",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Windows
+
+Edit `%APPDATA%\Claude\claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "C:\\path\\to\\jpx.exe",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## Verify Setup
+
+1. Restart Claude Desktop
+2. Look for the jpx tools in Claude's tool list
+3. Try a simple query:
+
+```
+User: I have this JSON: {"users": [{"name": "alice"}, {"name": "bob"}]}
+      Get all the names.
+
+Claude: [Uses jpx.evaluate]
+        Result: ["alice", "bob"]
+```
+
+## Strict Mode
+
+To use only standard JMESPath functions (no extensions):
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "jpx",
+      "args": ["mcp", "--strict"]
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### jpx not found
+
+Make sure jpx is in your PATH, or use the full path in the config.
+
+### Tools not appearing
+
+1. Check the config file syntax (must be valid JSON)
+2. Restart Claude Desktop completely
+3. Check Claude Desktop logs for errors
+
+### Permission errors on file access
+
+The `evaluate_file` tool has security restrictions. It only allows access to files in safe directories (not system paths).

--- a/docs/book/src/mcp/tools.md
+++ b/docs/book/src/mcp/tools.md
@@ -1,0 +1,4 @@
+# tools
+
+Coming soon.
+

--- a/docs/book/src/python/api.md
+++ b/docs/book/src/python/api.md
@@ -1,0 +1,4 @@
+# api
+
+Coming soon.
+

--- a/docs/book/src/python/installation.md
+++ b/docs/book/src/python/installation.md
@@ -1,0 +1,4 @@
+# installation
+
+Coming soon.
+

--- a/docs/book/src/python/usage.md
+++ b/docs/book/src/python/usage.md
@@ -1,0 +1,4 @@
+# usage
+
+Coming soon.
+


### PR DESCRIPTION
Adds a comprehensive documentation site using mdbook, deployed to GitHub Pages.

## Documentation Structure

```
docs/book/
├── book.toml           # mdbook configuration
└── src/
    ├── SUMMARY.md      # Table of contents
    ├── introduction.md
    ├── getting-started/
    │   ├── installation.md
    │   ├── quick-start.md
    │   └── basic-usage.md
    ├── guide/
    │   ├── cli-reference.md
    │   ├── expression-syntax.md
    │   └── ...
    ├── mcp/
    │   ├── overview.md
    │   ├── setup-claude.md
    │   └── ...
    ├── functions/
    │   ├── overview.md
    │   └── ...
    ├── python/
    │   └── ...
    └── examples/
        └── ...
```

## Completed Chapters

- Introduction and overview
- Getting started (installation, quick start, basic usage)
- CLI reference
- Expression syntax guide
- MCP server overview and Claude setup
- Function reference overview

## Placeholder Chapters

Several chapters have placeholder content ("Coming soon") that can be filled in incrementally.

## GitHub Pages Deployment

The `docs.yml` workflow:
- Triggers on pushes to main that modify `docs/book/**`
- Builds the mdbook
- Deploys to GitHub Pages

## Setup Required

After merging, enable GitHub Pages in repo settings:
1. Go to Settings → Pages
2. Source: GitHub Actions

The site will be available at: **https://joshrotenberg.github.io/jmespath-extensions/**