### PR TITLE
feat: add cartesian N-way product and with_entries (jq parity)

### DIFF
--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -327,6 +327,20 @@ examples = [
 ]
 features = ["core"]
 
+[[functions]]
+name = "cartesian"
+category = "array"
+description = "Compute cartesian product of arrays (jq parity for N-way product)"
+signature = "array, array? -> array"
+examples = [
+    { code = "cartesian([1, 2], [3, 4]) -> [[1, 3], [1, 4], [2, 3], [2, 4]]", description = "Two-array product" },
+    { code = "cartesian([[1, 2], [3, 4]]) -> [[1, 3], [1, 4], [2, 3], [2, 4]]", description = "N-way product (jq style)" },
+    { code = "cartesian([['a', 'b'], [1, 2], ['x', 'y']]) -> [['a', 1, 'x'], ['a', 1, 'y'], ...]", description = "Three-way product" },
+    { code = "cartesian([[1, 2]]) -> [[1], [2]]", description = "Single array" },
+    { code = "cartesian([[], [1, 2]]) -> []", description = "Empty array produces empty result" },
+]
+features = ["core"]
+
 # =============================================================================
 # COLOR FUNCTIONS
 # =============================================================================
@@ -2628,6 +2642,18 @@ examples = [
 ]
 jep = "JEP-013"
 features = ["core", "jep"]
+
+[[functions]]
+name = "with_entries"
+category = "object"
+description = "Transform object entries using an expression (jq parity)"
+signature = "object, string -> object"
+examples = [
+    { code = '''with_entries({a: 1, b: 2}, '[upper(@[0]), multiply(@[1], `2`)]') -> {A: 2, B: 4}''', description = "Transform keys and values" },
+    { code = '''with_entries({a: 1, b: 2}, '[@[0], add(@[1], `10`)]') -> {a: 11, b: 12}''', description = "Transform values only" },
+    { code = '''with_entries({a: 1, b: 2, c: 3}, 'if(@[1] > `1`, @, `null`)') -> {b: 2, c: 3}''', description = "Filter entries" },
+]
+features = ["core"]
 
 [[functions]]
 name = "leaves"

--- a/jmespath_extensions/src/array.rs
+++ b/jmespath_extensions/src/array.rs
@@ -1124,20 +1124,21 @@ impl Function for ModeFn {
 }
 
 // =============================================================================
-// cartesian(arr1, arr2) -> array (cartesian product)
+// cartesian(arr1, arr2) -> array (cartesian product of 2 arrays)
+// cartesian(array_of_arrays) -> array (cartesian product of N arrays, jq parity)
 // =============================================================================
 
 define_function!(
     CartesianFn,
-    vec![ArgumentType::Array, ArgumentType::Array],
-    None
+    vec![ArgumentType::Array],
+    Some(ArgumentType::Array)
 );
 
 impl Function for CartesianFn {
     fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
         self.signature.validate(args, ctx)?;
 
-        let arr1 = args[0].as_array().ok_or_else(|| {
+        let first = args[0].as_array().ok_or_else(|| {
             JmespathError::new(
                 ctx.expression,
                 0,
@@ -1145,24 +1146,99 @@ impl Function for CartesianFn {
             )
         })?;
 
-        let arr2 = args[1].as_array().ok_or_else(|| {
-            JmespathError::new(
-                ctx.expression,
-                0,
-                ErrorReason::Parse("Expected array argument".to_owned()),
-            )
-        })?;
+        // Two modes:
+        // 1. cartesian(arr1, arr2) - two separate arrays (original behavior)
+        // 2. cartesian(array_of_arrays) - single array containing arrays (jq-style)
 
-        let mut result = Vec::with_capacity(arr1.len() * arr2.len());
+        if args.len() == 2 {
+            // Original two-argument mode
+            let arr2 = args[1].as_array().ok_or_else(|| {
+                JmespathError::new(
+                    ctx.expression,
+                    0,
+                    ErrorReason::Parse("Expected array argument".to_owned()),
+                )
+            })?;
 
-        for a in arr1 {
-            for b in arr2 {
-                result.push(Rc::new(Variable::Array(vec![a.clone(), b.clone()])) as Rcvar);
+            let mut result = Vec::with_capacity(first.len() * arr2.len());
+            for a in first {
+                for b in arr2 {
+                    result.push(Rc::new(Variable::Array(vec![a.clone(), b.clone()])) as Rcvar);
+                }
+            }
+            Ok(Rc::new(Variable::Array(result)))
+        } else {
+            // Single argument mode - check if it's an array of arrays
+            // If all elements are arrays, do N-way cartesian product
+            let arrays: Vec<&Vec<Rcvar>> =
+                first.iter().filter_map(|item| item.as_array()).collect();
+
+            if arrays.len() != first.len() || arrays.is_empty() {
+                // Not all elements are arrays, or empty - return empty
+                return Ok(Rc::new(Variable::Array(vec![])));
+            }
+
+            // N-way cartesian product
+            let result = cartesian_product_n(&arrays);
+            Ok(Rc::new(Variable::Array(result)))
+        }
+    }
+}
+
+/// Compute N-way cartesian product of arrays
+fn cartesian_product_n(arrays: &[&Vec<Rcvar>]) -> Vec<Rcvar> {
+    if arrays.is_empty() {
+        return vec![];
+    }
+
+    if arrays.len() == 1 {
+        // Single array - each element becomes a 1-element tuple
+        return arrays[0]
+            .iter()
+            .map(|item| Rc::new(Variable::Array(vec![item.clone()])) as Rcvar)
+            .collect();
+    }
+
+    // Calculate total size for pre-allocation
+    let total_size: usize = arrays.iter().map(|a| a.len()).product();
+    if total_size == 0 {
+        return vec![];
+    }
+
+    let mut result = Vec::with_capacity(total_size);
+
+    // Iterative cartesian product using indices
+    let mut indices = vec![0usize; arrays.len()];
+
+    loop {
+        // Build current combination
+        let combo: Vec<Rcvar> = indices
+            .iter()
+            .enumerate()
+            .map(|(arr_idx, &elem_idx)| arrays[arr_idx][elem_idx].clone())
+            .collect();
+        result.push(Rc::new(Variable::Array(combo)) as Rcvar);
+
+        // Increment indices (like counting in mixed radix)
+        let mut carry = true;
+        for i in (0..arrays.len()).rev() {
+            if carry {
+                indices[i] += 1;
+                if indices[i] >= arrays[i].len() {
+                    indices[i] = 0;
+                } else {
+                    carry = false;
+                }
             }
         }
 
-        Ok(Rc::new(Variable::Array(result)))
+        // If we carried all the way through, we're done
+        if carry {
+            break;
+        }
     }
+
+    result
 }
 
 // =============================================================================
@@ -3002,6 +3078,46 @@ mod tests {
         let runtime = setup_runtime();
         let data = Variable::from_json(r#"{"a": [], "b": [1, 2]}"#).unwrap();
         let expr = runtime.compile("cartesian(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_cartesian_n_way_two_arrays() {
+        let runtime = setup_runtime();
+        let data = Variable::from_json(r#"[[1, 2], ["a", "b"]]"#).unwrap();
+        let expr = runtime.compile("cartesian(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 4); // [1,a], [1,b], [2,a], [2,b]
+    }
+
+    #[test]
+    fn test_cartesian_n_way_three_arrays() {
+        let runtime = setup_runtime();
+        let data = Variable::from_json(r#"[[1, 2], ["a", "b"], [true, false]]"#).unwrap();
+        let expr = runtime.compile("cartesian(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 8); // 2 * 2 * 2 = 8 combinations
+    }
+
+    #[test]
+    fn test_cartesian_n_way_single_array() {
+        let runtime = setup_runtime();
+        let data = Variable::from_json(r#"[[1, 2, 3]]"#).unwrap();
+        let expr = runtime.compile("cartesian(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // [1], [2], [3]
+    }
+
+    #[test]
+    fn test_cartesian_n_way_empty() {
+        let runtime = setup_runtime();
+        let data = Variable::from_json(r#"[]"#).unwrap();
+        let expr = runtime.compile("cartesian(@)").unwrap();
         let result = expr.search(&data).unwrap();
         let arr = result.as_array().unwrap();
         assert_eq!(arr.len(), 0);

--- a/jmespath_extensions/src/object.rs
+++ b/jmespath_extensions/src/object.rs
@@ -20,7 +20,8 @@ use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
 
 use crate::common::{
-    ArgumentType, Context, ErrorReason, Function, JmespathError, Rcvar, Runtime, Variable,
+    ArgumentType, Context, ErrorReason, Function, JmespathError, Rcvar, Runtime, Signature,
+    Variable,
 };
 use crate::define_function;
 
@@ -28,6 +29,7 @@ use crate::define_function;
 pub fn register(runtime: &mut Runtime) {
     runtime.register_function("items", Box::new(EntriesFn::new()));
     runtime.register_function("from_items", Box::new(FromEntriesFn::new()));
+    runtime.register_function("with_entries", Box::new(WithEntriesFn::new()));
     runtime.register_function("pick", Box::new(PickFn::new()));
     runtime.register_function("omit", Box::new(OmitFn::new()));
     runtime.register_function("invert", Box::new(InvertFn::new()));
@@ -145,6 +147,111 @@ impl Function for FromEntriesFn {
                     // Key must be a string
                     if let Some(key_str) = pair[0].as_string() {
                         result.insert(key_str.to_string(), pair[1].clone());
+                    }
+                }
+            }
+        }
+
+        Ok(Rc::new(Variable::Object(result)))
+    }
+}
+
+// =============================================================================
+// with_entries(object, expr) -> object (transform entries, jq parity)
+// =============================================================================
+
+// Transform object entries using an expression.
+// Equivalent to: from_items(map(expr, items(object)))
+//
+// The expression receives each entry as a [key, value] pair and should return
+// a [key, value] pair (or null to remove the entry).
+//
+// # Arguments
+// * `object` - The object to transform
+// * `expr` - A JMESPath expression string that transforms [key, value] pairs
+//
+// # Returns
+// A new object with transformed entries.
+//
+// # Example
+// with_entries({a: 1, b: 2}, '[upper(@[`0`]), @[`1`] * `2`]') -> {A: 2, B: 4}
+
+pub struct WithEntriesFn {
+    signature: Signature,
+}
+
+impl Default for WithEntriesFn {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WithEntriesFn {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(vec![ArgumentType::Object, ArgumentType::String], None),
+        }
+    }
+}
+
+impl Function for WithEntriesFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let obj = args[0].as_object().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected object argument".to_owned()),
+            )
+        })?;
+
+        let expr_str = args[1].as_string().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected expression string".to_owned()),
+            )
+        })?;
+
+        // Compile the expression
+        let compiled = ctx.runtime.compile(expr_str).map_err(|e| {
+            JmespathError::new(
+                ctx.expression,
+                ctx.offset,
+                ErrorReason::Parse(format!("Invalid expression in with_entries: {}", e)),
+            )
+        })?;
+
+        let mut result = BTreeMap::new();
+
+        // Apply expression to each [key, value] entry
+        for (key, value) in obj.iter() {
+            // Create [key, value] pair
+            let entry = Rc::new(Variable::Array(vec![
+                Rc::new(Variable::String(key.clone())) as Rcvar,
+                value.clone(),
+            ]));
+
+            // Apply transformation
+            let transformed = compiled.search(entry).map_err(|e| {
+                JmespathError::new(
+                    ctx.expression,
+                    ctx.offset,
+                    ErrorReason::Parse(format!("Expression error in with_entries: {}", e)),
+                )
+            })?;
+
+            // Skip null results (allows filtering entries)
+            if transformed.is_null() {
+                continue;
+            }
+
+            // Result should be a [key, value] pair
+            if let Some(pair) = transformed.as_array() {
+                if pair.len() >= 2 {
+                    if let Some(new_key) = pair[0].as_string() {
+                        result.insert(new_key.to_string(), pair[1].clone());
                     }
                 }
             }
@@ -3154,6 +3261,70 @@ mod tests {
         assert_eq!(obj.get("a").unwrap().as_number().unwrap() as i64, 1);
         assert_eq!(obj.get("b").unwrap().as_string().unwrap(), "hello");
         assert!(obj.get("c").unwrap().as_boolean().unwrap());
+    }
+
+    #[test]
+    fn test_with_entries_identity() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("with_entries(@, '[@[0], @[1]]')").unwrap();
+        let data = Variable::from_json(r#"{"a": 1, "b": 2}"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("a").unwrap().as_number().unwrap() as i64, 1);
+        assert_eq!(obj.get("b").unwrap().as_number().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_with_entries_transform_keys() {
+        // Test that we can transform keys by prepending a prefix
+        // Using join to concatenate strings (built-in)
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile(r#"with_entries(@, '[join(`""`, [`"prefix_"`, @[0]]), @[1]]')"#)
+            .unwrap();
+        let data = Variable::from_json(r#"{"a": 1, "b": 2}"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("prefix_a"));
+        assert!(obj.contains_key("prefix_b"));
+    }
+
+    #[test]
+    fn test_with_entries_swap_key_value() {
+        // Test swapping keys and values (for string values)
+        let runtime = setup_runtime();
+        let expr = runtime.compile("with_entries(@, '[@[1], @[0]]')").unwrap();
+        let data = Variable::from_json(r#"{"a": "x", "b": "y"}"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("x").unwrap().as_string().unwrap(), "a");
+        assert_eq!(obj.get("y").unwrap().as_string().unwrap(), "b");
+    }
+
+    #[test]
+    fn test_with_entries_filter_null() {
+        // Test that returning null from the expression skips entries
+        // This tests the filtering behavior of with_entries
+        let runtime = setup_runtime();
+        // Return null for all entries - result should be empty object
+        let expr = runtime.compile(r#"with_entries(@, '`null`')"#).unwrap();
+        let data = Variable::from_json(r#"{"a": 1, "b": 2}"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 0);
+    }
+
+    #[test]
+    fn test_with_entries_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("with_entries(@, '[@[0], @[1]]')").unwrap();
+        let data = Variable::from_json(r#"{}"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds two jq parity functions:

### cartesian N-way extension
Extends `cartesian()` to support both modes (backwards compatible):
- `cartesian(arr1, arr2)` - original two-argument mode
- `cartesian([[arr1], [arr2], ...])` - N-way cartesian product (jq style)

### with_entries
Adds `with_entries(obj, expr)` function for transforming object entries:
- Equivalent to `from_items(map(expr, items(obj)))`
- Expression receives `[key, value]` pairs and should return transformed pairs
- Returning null from the expression filters out entries

## Examples

```bash
# N-way cartesian product
jpx -e 'cartesian([["a", "b"], [1, 2], ["x", "y"]])' null
# [["a", 1, "x"], ["a", 1, "y"], ["a", 2, "x"], ...]

# with_entries - transform keys
jpx -e "with_entries(@, '[@[0], @[1]]')" '{"a": 1, "b": 2}'
# {"a": 1, "b": 2}
```

## Addresses
- #249 (cartesian product)
- #253 (with_entries)

## Checklist
- [x] Tests added
- [x] functions.toml updated
- [x] All tests pass