### PR TITLE
feat(cli): add --paths and --table flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -142,6 +142,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -265,10 +271,10 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -455,7 +461,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -466,7 +472,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -515,7 +521,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -562,7 +568,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -609,6 +615,12 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -681,7 +693,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -780,6 +792,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1094,6 +1112,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tabled",
  "tempfile",
  "tokio",
  "toml",
@@ -1315,6 +1334,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "papergrid"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1462,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,7 +1539,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1496,11 +1548,11 @@ version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1644,7 +1696,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1708,7 +1760,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1817,7 +1869,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1829,7 +1881,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1871,7 +1923,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1882,7 +1934,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2025,6 +2077,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
@@ -2042,7 +2105,30 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "tabled"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2090,7 +2176,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2101,7 +2187,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2158,7 +2244,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2234,7 +2320,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2432,7 +2518,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -2526,7 +2612,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2537,7 +2623,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2775,7 +2861,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -2796,7 +2882,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2816,7 +2902,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -2850,5 +2936,5 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -39,6 +39,7 @@ json-patch.workspace = true
 serde_yaml = "0.9"
 toml = "0.8"
 csv = "1.3"
+tabled = "0.17"
 
 # MCP server (optional)
 rmcp = { workspace = true, optional = true }

--- a/jpx/src/main.rs
+++ b/jpx/src/main.rs
@@ -146,8 +146,21 @@ struct Args {
     tsv_output: bool,
 
     /// Output one JSON value per line (for arrays)
-    #[arg(short = 'l', long = "lines", conflicts_with_all = ["yaml", "toml_output", "csv_output", "tsv_output"])]
+    #[arg(short = 'l', long = "lines", conflicts_with_all = ["yaml", "toml_output", "csv_output", "tsv_output", "table"])]
     lines_output: bool,
+
+    /// Output as a formatted table (for arrays of objects)
+    #[arg(short = 't', long, conflicts_with_all = ["yaml", "toml_output", "csv_output", "tsv_output", "lines_output"])]
+    table: bool,
+
+    /// Table style: unicode (default), ascii, markdown, or plain
+    #[arg(
+        long,
+        value_name = "STYLE",
+        default_value = "unicode",
+        requires = "table"
+    )]
+    table_style: String,
 
     /// Null input - don't read input, use null as the input value
     #[arg(short = 'n', long)]
@@ -227,6 +240,18 @@ struct Args {
     /// Show statistics about the input data
     #[arg(long)]
     stats: bool,
+
+    /// List all paths in the input JSON
+    #[arg(long)]
+    paths: bool,
+
+    /// Show types alongside paths (use with --paths)
+    #[arg(long, requires = "paths")]
+    types: bool,
+
+    /// Show values alongside paths (use with --paths)
+    #[arg(long, requires = "paths")]
+    values: bool,
 }
 
 fn main() -> Result<()> {
@@ -294,6 +319,11 @@ fn main() -> Result<()> {
     // Handle --stats: show data statistics
     if args.stats {
         return show_stats(&args.file, &args.color);
+    }
+
+    // Handle --paths: list all paths in JSON
+    if args.paths {
+        return show_paths(&args.file, &args.color, args.types, args.values);
     }
 
     // Get expressions from positional args, -e flags, or file
@@ -460,6 +490,9 @@ fn main() -> Result<()> {
     }
     if args.lines_output {
         return output_as_lines(&json_value, &args.output);
+    }
+    if args.table {
+        return output_as_table(&json_value, &args.output, &args.table_style, &args.color);
     }
 
     // When writing to file, don't colorize unless explicitly requested
@@ -1674,6 +1707,377 @@ fn value_to_cell(value: &serde_json::Value) -> String {
         // Arrays and objects get JSON-encoded in the cell
         serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
             serde_json::to_string(value).unwrap_or_default()
+        }
+    }
+}
+
+// =============================================================================
+// Table Output
+// =============================================================================
+
+/// Output as a formatted table
+fn output_as_table(
+    value: &serde_json::Value,
+    output_path: &Option<String>,
+    style: &str,
+    color_mode: &ColorMode,
+) -> Result<()> {
+    let use_color = match color_mode {
+        ColorMode::Always => true,
+        ColorMode::Never => false,
+        ColorMode::Auto => output_path.is_none() && atty::is(atty::Stream::Stdout),
+    };
+
+    match value {
+        serde_json::Value::Array(arr) => {
+            if arr.is_empty() {
+                return write_output("(empty array)", output_path);
+            }
+
+            // Check if all items are objects
+            let all_objects = arr.iter().all(|v| v.is_object());
+
+            if all_objects {
+                output_objects_as_table(arr, output_path, style, use_color)
+            } else {
+                // Array of primitives or mixed - single column table
+                output_primitives_as_table(arr, output_path, style)
+            }
+        }
+        serde_json::Value::Object(_) => {
+            // Single object - output as key/value table
+            output_objects_as_table(std::slice::from_ref(value), output_path, style, use_color)
+        }
+        _ => Err(anyhow::anyhow!(
+            "Table output requires an array or object, got {}",
+            get_type_name(value)
+        )),
+    }
+}
+
+/// Output array of objects as a table
+fn output_objects_as_table(
+    arr: &[serde_json::Value],
+    output_path: &Option<String>,
+    style: &str,
+    use_color: bool,
+) -> Result<()> {
+    use tabled::{Table, settings::Style};
+
+    // Collect all unique keys from all objects (flattened)
+    let mut all_keys: Vec<String> = Vec::new();
+    let mut seen_keys = std::collections::HashSet::new();
+
+    for item in arr {
+        if let serde_json::Value::Object(obj) = item {
+            collect_flattened_keys(obj, "", &mut all_keys, &mut seen_keys);
+        }
+    }
+
+    if all_keys.is_empty() {
+        return write_output("(no columns)", output_path);
+    }
+
+    // Build rows
+    let mut rows: Vec<Vec<String>> = Vec::new();
+
+    // Header row
+    let header: Vec<String> = if use_color {
+        all_keys.iter().map(|k| k.bold().to_string()).collect()
+    } else {
+        all_keys.clone()
+    };
+    rows.push(header);
+
+    // Data rows
+    for item in arr {
+        let flattened = flatten_object(item);
+        let row: Vec<String> = all_keys
+            .iter()
+            .map(|key| {
+                flattened
+                    .get(key)
+                    .map(|v| value_to_table_cell(v, use_color))
+                    .unwrap_or_default()
+            })
+            .collect();
+        rows.push(row);
+    }
+
+    // Create table
+    let mut table = Table::from_iter(rows);
+
+    // Apply style
+    match style.to_lowercase().as_str() {
+        "ascii" => {
+            table.with(Style::ascii());
+        }
+        "markdown" | "md" => {
+            table.with(Style::markdown());
+        }
+        "plain" | "blank" => {
+            table.with(Style::blank());
+        }
+        "rounded" => {
+            table.with(Style::rounded());
+        }
+        "sharp" => {
+            table.with(Style::sharp());
+        }
+        "modern" => {
+            table.with(Style::modern());
+        }
+        _ => {
+            table.with(Style::rounded());
+        } // unicode/default
+    };
+
+    write_output(&table.to_string(), output_path)
+}
+
+/// Output array of primitives as a single-column table
+fn output_primitives_as_table(
+    arr: &[serde_json::Value],
+    output_path: &Option<String>,
+    style: &str,
+) -> Result<()> {
+    use tabled::{Table, settings::Style};
+
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    rows.push(vec!["Value".to_string()]);
+
+    for item in arr {
+        rows.push(vec![value_to_table_cell(item, false)]);
+    }
+
+    let mut table = Table::from_iter(rows);
+
+    match style.to_lowercase().as_str() {
+        "ascii" => {
+            table.with(Style::ascii());
+        }
+        "markdown" | "md" => {
+            table.with(Style::markdown());
+        }
+        "plain" | "blank" => {
+            table.with(Style::blank());
+        }
+        "rounded" => {
+            table.with(Style::rounded());
+        }
+        "sharp" => {
+            table.with(Style::sharp());
+        }
+        "modern" => {
+            table.with(Style::modern());
+        }
+        _ => {
+            table.with(Style::rounded());
+        }
+    };
+
+    write_output(&table.to_string(), output_path)
+}
+
+/// Convert a JSON value to a table cell string
+fn value_to_table_cell(value: &serde_json::Value, use_color: bool) -> String {
+    match value {
+        serde_json::Value::Null => {
+            if use_color {
+                "null".dimmed().to_string()
+            } else {
+                "null".to_string()
+            }
+        }
+        serde_json::Value::Bool(b) => {
+            if use_color {
+                if *b {
+                    "true".green().to_string()
+                } else {
+                    "false".red().to_string()
+                }
+            } else {
+                b.to_string()
+            }
+        }
+        serde_json::Value::Number(n) => {
+            if use_color {
+                n.to_string().cyan().to_string()
+            } else {
+                n.to_string()
+            }
+        }
+        serde_json::Value::String(s) => {
+            // Truncate long strings
+            if s.len() <= 40 {
+                s.clone()
+            } else {
+                format!("{}...", &s[..37])
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            if use_color {
+                format!("[{} items]", arr.len()).dimmed().to_string()
+            } else {
+                format!("[{} items]", arr.len())
+            }
+        }
+        serde_json::Value::Object(obj) => {
+            if use_color {
+                format!("{{{} keys}}", obj.len()).dimmed().to_string()
+            } else {
+                format!("{{{} keys}}", obj.len())
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Path Listing
+// =============================================================================
+
+/// Show all paths in the JSON data
+fn show_paths(
+    file_path: &Option<String>,
+    color_mode: &ColorMode,
+    show_types: bool,
+    show_values: bool,
+) -> Result<()> {
+    let data = read_json_from(file_path.as_deref())?;
+
+    let use_color = match color_mode {
+        ColorMode::Always => true,
+        ColorMode::Never => false,
+        ColorMode::Auto => atty::is(atty::Stream::Stdout),
+    };
+
+    let mut paths_info: Vec<(String, String, Option<String>)> = Vec::new();
+    collect_paths(&data, String::new(), &mut paths_info);
+
+    // Calculate max widths for alignment
+    let max_path_width = paths_info
+        .iter()
+        .map(|(p, _, _)| p.len())
+        .max()
+        .unwrap_or(0);
+    let max_type_width = if show_types {
+        paths_info
+            .iter()
+            .map(|(_, t, _)| t.len())
+            .max()
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    for (path, type_name, value) in &paths_info {
+        let path_display = if use_color {
+            path.cyan().to_string()
+        } else {
+            path.clone()
+        };
+
+        if show_types && show_values {
+            let type_display = if use_color {
+                format!("{:width$}", type_name, width = max_type_width)
+                    .yellow()
+                    .to_string()
+            } else {
+                format!("{:width$}", type_name, width = max_type_width)
+            };
+            let value_display = value.as_deref().unwrap_or("");
+            println!(
+                "{:width$}  {}  {}",
+                path_display,
+                type_display,
+                value_display,
+                width = max_path_width
+            );
+        } else if show_types {
+            let type_display = if use_color {
+                type_name.yellow().to_string()
+            } else {
+                type_name.clone()
+            };
+            println!(
+                "{:width$}  {}",
+                path_display,
+                type_display,
+                width = max_path_width
+            );
+        } else if show_values {
+            let value_display = value.as_deref().unwrap_or("");
+            println!(
+                "{:width$}  {}",
+                path_display,
+                value_display,
+                width = max_path_width
+            );
+        } else {
+            println!("{}", path_display);
+        }
+    }
+
+    Ok(())
+}
+
+/// Recursively collect all paths from a JSON value
+fn collect_paths(
+    value: &serde_json::Value,
+    current_path: String,
+    paths: &mut Vec<(String, String, Option<String>)>,
+) {
+    let display_path = if current_path.is_empty() {
+        ".".to_string()
+    } else {
+        current_path.clone()
+    };
+
+    match value {
+        serde_json::Value::Object(obj) => {
+            // Add the object path itself
+            let type_name = format!("object{{{}}}", obj.len());
+            paths.push((display_path, type_name, None));
+
+            for (key, val) in obj {
+                let new_path = if current_path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{}.{}", current_path, key)
+                };
+                collect_paths(val, new_path, paths);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            // Add the array path itself
+            let type_name = format!("array[{}]", arr.len());
+            paths.push((display_path, type_name, None));
+
+            for (i, val) in arr.iter().enumerate() {
+                let new_path = if current_path.is_empty() {
+                    format!("[{}]", i)
+                } else {
+                    format!("{}[{}]", current_path, i)
+                };
+                collect_paths(val, new_path, paths);
+            }
+        }
+        serde_json::Value::String(s) => {
+            let preview = if s.len() <= 40 {
+                format!("\"{}\"", s)
+            } else {
+                format!("\"{}...\"", &s[..37])
+            };
+            paths.push((display_path, "string".to_string(), Some(preview)));
+        }
+        serde_json::Value::Number(n) => {
+            paths.push((display_path, "number".to_string(), Some(n.to_string())));
+        }
+        serde_json::Value::Bool(b) => {
+            paths.push((display_path, "boolean".to_string(), Some(b.to_string())));
+        }
+        serde_json::Value::Null => {
+            paths.push((display_path, "null".to_string(), Some("null".to_string())));
         }
     }
 }

--- a/jpx/tests/integration.rs
+++ b/jpx/tests/integration.rs
@@ -1013,6 +1013,169 @@ mod validation_functions {
     }
 }
 
+mod cli_paths {
+    use super::*;
+
+    fn run_with_flags(json: &str, flags: &[&str]) -> String {
+        let mut cmd = jpx_cmd();
+        for flag in flags {
+            cmd.arg(flag);
+        }
+        let mut child = cmd
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn jpx");
+
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(json.as_bytes())
+            .expect("Failed to write to stdin");
+
+        let output = child.wait_with_output().expect("Failed to wait on jpx");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn test_paths_basic() {
+        let result = run_with_flags(r#"{"name": "alice", "age": 30}"#, &["--paths"]);
+        assert!(result.contains("."));
+        assert!(result.contains("name"));
+        assert!(result.contains("age"));
+    }
+
+    #[test]
+    fn test_paths_nested() {
+        let result = run_with_flags(r#"{"user": {"name": "alice"}}"#, &["--paths"]);
+        assert!(result.contains("user"));
+        assert!(result.contains("user.name"));
+    }
+
+    #[test]
+    fn test_paths_array() {
+        let result = run_with_flags(r#"{"items": [1, 2, 3]}"#, &["--paths"]);
+        assert!(result.contains("items"));
+        assert!(result.contains("items[0]"));
+        assert!(result.contains("items[1]"));
+        assert!(result.contains("items[2]"));
+    }
+
+    #[test]
+    fn test_paths_with_types() {
+        let result = run_with_flags(r#"{"name": "alice", "age": 30}"#, &["--paths", "--types"]);
+        assert!(result.contains("string"));
+        assert!(result.contains("number"));
+        assert!(result.contains("object"));
+    }
+
+    #[test]
+    fn test_paths_with_values() {
+        let result = run_with_flags(r#"{"name": "alice"}"#, &["--paths", "--values"]);
+        assert!(result.contains("\"alice\""));
+    }
+
+    #[test]
+    fn test_paths_with_types_and_values() {
+        let result = run_with_flags(r#"{"count": 42}"#, &["--paths", "--types", "--values"]);
+        assert!(result.contains("number"));
+        assert!(result.contains("42"));
+    }
+}
+
+mod cli_table {
+    use super::*;
+
+    fn run_with_flags(json: &str, flags: &[&str]) -> String {
+        let mut cmd = jpx_cmd();
+        for flag in flags {
+            cmd.arg(flag);
+        }
+        let mut child = cmd
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn jpx");
+
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(json.as_bytes())
+            .expect("Failed to write to stdin");
+
+        let output = child.wait_with_output().expect("Failed to wait on jpx");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn test_table_basic() {
+        let result = run_with_flags(
+            r#"[{"name": "alice", "age": 30}]"#,
+            &["@", "--table", "--color", "never"],
+        );
+        assert!(result.contains("name"));
+        assert!(result.contains("age"));
+        assert!(result.contains("alice"));
+        assert!(result.contains("30"));
+    }
+
+    #[test]
+    fn test_table_multiple_rows() {
+        let result = run_with_flags(
+            r#"[{"name": "alice"}, {"name": "bob"}]"#,
+            &["@", "--table", "--color", "never"],
+        );
+        assert!(result.contains("alice"));
+        assert!(result.contains("bob"));
+    }
+
+    #[test]
+    fn test_table_ascii_style() {
+        let result = run_with_flags(
+            r#"[{"name": "alice"}]"#,
+            &["@", "--table", "--table-style", "ascii"],
+        );
+        assert!(result.contains("+"));
+        assert!(result.contains("-"));
+        assert!(result.contains("|"));
+    }
+
+    #[test]
+    fn test_table_markdown_style() {
+        let result = run_with_flags(
+            r#"[{"name": "alice"}]"#,
+            &["@", "--table", "--table-style", "markdown"],
+        );
+        // Markdown tables use | for columns
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(lines.len() >= 2);
+        assert!(lines[0].contains("|"));
+        // Second line should be the separator with dashes
+        assert!(lines[1].contains("-"));
+    }
+
+    #[test]
+    fn test_table_with_expression() {
+        let result = run_with_flags(
+            r#"[{"user": {"name": "alice"}}, {"user": {"name": "bob"}}]"#,
+            &["[*].user", "--table", "--color", "never"],
+        );
+        assert!(result.contains("alice"));
+        assert!(result.contains("bob"));
+    }
+
+    #[test]
+    fn test_table_short_flag() {
+        let result = run_with_flags(r#"[{"name": "alice"}]"#, &["@", "-t", "--color", "never"]);
+        assert!(result.contains("name"));
+        assert!(result.contains("alice"));
+    }
+}
+
 mod output_formats {
     use super::*;
 


### PR DESCRIPTION
## Summary

Adds two new CLI flags for exploring and displaying JSON data.

### `--paths` - List all JSON paths

List all paths in the input JSON, useful for exploring structure and building queries.

```bash
$ echo '{"user":{"name":"Alice","tags":["a","b"]}}' | jpx --paths
.
user
user.name
user.tags
user.tags[0]
user.tags[1]
```

With types:
```bash
$ echo '{"user":{"name":"Alice"}}' | jpx --paths --types
.           object{1}
user        object{1}
user.name   string
```

With values:
```bash
$ echo '{"count": 42}' | jpx --paths --types --values
.      object{1}
count  number     42
```

### `--table` / `-t` - Formatted table output

Output arrays of objects as formatted ASCII/Unicode tables.

```bash
$ echo '[{"name":"Alice","age":30},{"name":"Bob","age":25}]' | jpx '@' --table

╭─────┬───────╮
│ age │ name  │
├─────┼───────┤
│ 30  │ Alice │
│ 25  │ Bob   │
╰─────┴───────╯
```

Table styles:
- `--table-style unicode` (default) - Rounded Unicode borders
- `--table-style ascii` - ASCII-only borders (`+`, `-`, `|`)
- `--table-style markdown` - Markdown table format
- `--table-style plain` - No borders

```bash
$ jpx '@' --table --table-style markdown -f users.json
| age | name  |
|-----|-------|
| 30  | Alice |
| 25  | Bob   |
```

## Tests

Adds 12 integration tests covering both features.

Closes #238
Closes #236