### PR TITLE
docs: add curated examples with real-world datasets

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -50,3 +50,10 @@
 - [Log Processing](./examples/log-processing.md)
 - [API Response Handling](./examples/api-responses.md)
 - [jq Comparison](./examples/jq-comparison.md)
+
+# Real-World Datasets
+
+- [Overview](./examples/datasets/index.md)
+- [USGS Earthquakes](./examples/datasets/earthquakes.md)
+- [Nobel Prize API](./examples/datasets/nobel-prize.md)
+- [NASA Near Earth Objects](./examples/datasets/nasa-neo.md)

--- a/docs/book/src/examples/datasets/earthquakes.md
+++ b/docs/book/src/examples/datasets/earthquakes.md
@@ -1,0 +1,426 @@
+# USGS Earthquake Data
+
+The [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/) provides real-time earthquake data via a public API. This dataset is excellent for learning jpx because it has:
+
+- Nested GeoJSON structure
+- Numeric data for statistical analysis (magnitude, depth)
+- Geographic coordinates for geo functions
+- Timestamps for date/time operations
+
+## Getting the Data
+
+```bash
+# Fetch recent magnitude 5+ earthquakes (10 events)
+curl -s "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&limit=10&minmagnitude=5" > earthquakes.json
+
+# Fetch more data to play with (100 events)
+curl -s "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&limit=100&minmagnitude=4" > earthquakes_100.json
+```
+
+## Data Structure
+
+The API returns GeoJSON with this structure:
+
+```json
+{
+  "type": "FeatureCollection",
+  "metadata": {
+    "generated": 1768410727000,
+    "title": "USGS Earthquakes",
+    "count": 10
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "mag": 6.2,
+        "place": "133 km SE of Kuril'sk, Russia",
+        "time": 1768289648725,
+        "sig": 591,
+        "tsunami": 0,
+        "type": "earthquake",
+        "title": "M 6.2 - 133 km SE of Kuril'sk, Russia"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [149.2768, 44.5495, 35.788]
+      },
+      "id": "us7000rpcg"
+    }
+  ]
+}
+```
+
+Key fields:
+- `properties.mag` - Magnitude
+- `properties.place` - Human-readable location
+- `properties.time` - Unix timestamp (milliseconds)
+- `properties.sig` - Significance (0-1000+)
+- `geometry.coordinates` - [longitude, latitude, depth_km]
+
+---
+
+## Basic Queries
+
+### List All Earthquake Titles
+
+```bash
+jpx 'features[*].properties.title' earthquakes.json
+```
+
+Output:
+```json
+[
+  "M 5.1 - 119 km N of Lae, Papua New Guinea",
+  "M 5.1 - 68 km E of Severo-Kuril'sk, Russia",
+  "M 6.2 - 133 km SE of Kuril'sk, Russia",
+  ...
+]
+```
+
+### Get Magnitudes Only
+
+```bash
+jpx 'features[*].properties.mag' earthquakes.json
+```
+
+Output:
+```json
+[5.1, 5.1, 6.2, 5.3, 5.6, 5.2, 5.2, 5.1, 5.0, 5.6]
+```
+
+### Count Total Events
+
+```bash
+jpx 'length(features)' earthquakes.json
+```
+
+Output: `10`
+
+---
+
+## Filtering
+
+### Find Major Earthquakes (Magnitude 6+)
+
+```bash
+jpx 'features[?properties.mag >= `6`].properties.title' earthquakes.json
+```
+
+Output:
+```json
+["M 6.2 - 133 km SE of Kuril'sk, Russia"]
+```
+
+### Find Deep Earthquakes (> 100km depth)
+
+The depth is the third element in the coordinates array:
+
+```bash
+jpx 'features[?geometry.coordinates[2] > `100`].{
+  title: properties.title,
+  depth_km: geometry.coordinates[2]
+}' earthquakes.json
+```
+
+Output:
+```json
+[
+  {"title": "M 5.1 - 119 km N of Lae, Papua New Guinea", "depth_km": 172.746},
+  {"title": "M 5.3 - 72 km W of Ollagüe, Chile", "depth_km": 118.039},
+  {"title": "M 5.1 - 233 km ENE of Lospalos, Timor Leste", "depth_km": 101.686}
+]
+```
+
+### Find Earthquakes with Tsunami Alerts
+
+```bash
+jpx 'features[?properties.tsunami == `1`].properties.title' earthquakes.json
+```
+
+### Filter by Location (Text Match)
+
+```bash
+jpx 'features[?contains(properties.place, `Russia`)].properties.title' earthquakes.json
+```
+
+Output:
+```json
+[
+  "M 5.1 - 68 km E of Severo-Kuril'sk, Russia",
+  "M 6.2 - 133 km SE of Kuril'sk, Russia",
+  "M 5.2 - 177 km S of Severo-Kuril'sk, Russia",
+  "M 5.6 - 265 km N of Kuril'sk, Russia"
+]
+```
+
+---
+
+## Statistics
+
+### Average Magnitude
+
+```bash
+jpx 'avg(features[*].properties.mag)' earthquakes.json
+```
+
+Output: `5.34`
+
+### Magnitude Statistics
+
+```bash
+jpx '{
+  count: length(features),
+  min: min(features[*].properties.mag),
+  max: max(features[*].properties.mag),
+  avg: avg(features[*].properties.mag),
+  median: median(features[*].properties.mag),
+  stddev: round(stddev(features[*].properties.mag), `3`)
+}' earthquakes.json
+```
+
+Output:
+```json
+{
+  "count": 10,
+  "min": 5.0,
+  "max": 6.2,
+  "avg": 5.34,
+  "median": 5.2,
+  "stddev": 0.351
+}
+```
+
+### Depth Statistics
+
+```bash
+jpx '{
+  shallowest: min(features[*].geometry.coordinates[2]),
+  deepest: max(features[*].geometry.coordinates[2]),
+  avg_depth: round(avg(features[*].geometry.coordinates[2]), `1`)
+}' earthquakes.json
+```
+
+---
+
+## Sorting
+
+### Sort by Magnitude (Descending)
+
+```bash
+jpx 'sort_by(features, &properties.mag) | reverse(@) | [*].{
+  mag: properties.mag,
+  place: properties.place
+}' earthquakes.json
+```
+
+Output:
+```json
+[
+  {"mag": 6.2, "place": "133 km SE of Kuril'sk, Russia"},
+  {"mag": 5.6, "place": "Easter Island region"},
+  {"mag": 5.6, "place": "265 km N of Kuril'sk, Russia"},
+  ...
+]
+```
+
+### Top 3 by Significance
+
+```bash
+jpx 'sort_by(features, &properties.sig) | reverse(@) | [:3] | [*].{
+  significance: properties.sig,
+  title: properties.title
+}' earthquakes.json
+```
+
+---
+
+## Geographic Calculations
+
+### Extract Coordinates
+
+```bash
+jpx 'features[*].{
+  place: properties.place,
+  lat: geometry.coordinates[1],
+  lon: geometry.coordinates[0]
+}' earthquakes.json
+```
+
+### Distance from a Reference Point
+
+Calculate distance from San Francisco (37.7749, -122.4194) using the `haversine` function:
+
+```bash
+jpx 'features[*].{
+  place: properties.place,
+  distance_km: round(haversine(
+    `37.7749`, `-122.4194`,
+    geometry.coordinates[1], geometry.coordinates[0]
+  ), `0`)
+} | sort_by(@, &distance_km)' earthquakes.json
+```
+
+Output:
+```json
+[
+  {"place": "Easter Island region", "distance_km": 7580},
+  {"place": "72 km W of Ollagüe, Chile", "distance_km": 9513},
+  {"place": "South Sandwich Islands region", "distance_km": 12748},
+  ...
+]
+```
+
+### Find Nearest Earthquake
+
+```bash
+jpx 'min_by(features, &haversine(
+  `37.7749`, `-122.4194`,
+  geometry.coordinates[1], geometry.coordinates[0]
+)).properties.title' earthquakes.json
+```
+
+---
+
+## Date/Time Operations
+
+### Convert Timestamps to Readable Dates
+
+The `time` field is Unix milliseconds. Convert to ISO format:
+
+```bash
+jpx 'features[*].{
+  title: properties.title,
+  date: from_unixtime(floor(divide(properties.time, `1000`)))
+}' earthquakes.json
+```
+
+### Find Earthquakes in Last 24 Hours
+
+```bash
+jpx --let now='now()' 'features[?properties.time > multiply(subtract($now, `86400`), `1000`)].properties.title' earthquakes.json
+```
+
+### Group by Day
+
+```bash
+jpx 'features[*].{
+  day: format_datetime(from_unixtime(floor(divide(properties.time, `1000`))), `%Y-%m-%d`),
+  mag: properties.mag,
+  place: properties.place
+}' earthquakes.json
+```
+
+---
+
+## Data Transformation
+
+### Reshape to Flat Structure
+
+```bash
+jpx 'features[*].{
+  id: id,
+  magnitude: properties.mag,
+  location: properties.place,
+  longitude: geometry.coordinates[0],
+  latitude: geometry.coordinates[1],
+  depth_km: geometry.coordinates[2],
+  timestamp: properties.time,
+  url: properties.url
+}' earthquakes.json
+```
+
+### Export to CSV
+
+```bash
+jpx --csv 'features[*].{
+  magnitude: properties.mag,
+  location: properties.place,
+  latitude: geometry.coordinates[1],
+  longitude: geometry.coordinates[0],
+  depth_km: geometry.coordinates[2]
+}' earthquakes.json
+```
+
+Output:
+```csv
+magnitude,location,latitude,longitude,depth_km
+5.1,"119 km N of Lae, Papua New Guinea",-5.6511,147.12,172.746
+5.1,"68 km E of Severo-Kuril'sk, Russia",50.7928,157.0843,64.364
+6.2,"133 km SE of Kuril'sk, Russia",44.5495,149.2768,35.788
+...
+```
+
+---
+
+## Advanced Pipelines
+
+### Summary Report
+
+Create a comprehensive earthquake summary:
+
+```bash
+jpx '{
+  report_title: `USGS Earthquake Summary`,
+  generated: metadata.title,
+  total_events: length(features),
+  magnitude_stats: {
+    min: min(features[*].properties.mag),
+    max: max(features[*].properties.mag),
+    average: round(avg(features[*].properties.mag), `2`),
+    median: median(features[*].properties.mag)
+  },
+  depth_stats: {
+    shallowest_km: min(features[*].geometry.coordinates[2]),
+    deepest_km: max(features[*].geometry.coordinates[2])
+  },
+  major_events: features[?properties.mag >= `5.5`] | [*].{
+    magnitude: properties.mag,
+    location: properties.place
+  },
+  by_region: {
+    russia: length(features[?contains(properties.place, `Russia`)]),
+    indonesia: length(features[?contains(properties.place, `Indonesia`)]),
+    chile: length(features[?contains(properties.place, `Chile`)])
+  }
+}' earthquakes.json
+```
+
+### Pipeline with Multiple Steps
+
+```bash
+# Get major earthquakes, sort by magnitude, format for display
+jpx 'features 
+  | [?properties.mag >= `5.5`] 
+  | sort_by(@, &properties.mag) 
+  | reverse(@) 
+  | [*].{
+      mag: properties.mag,
+      where: properties.place,
+      depth: join(``, [to_string(geometry.coordinates[2]), ` km`])
+    }' earthquakes.json
+```
+
+---
+
+## Try It Yourself
+
+1. **Fetch live data**: The USGS API updates in real-time
+   ```bash
+   curl -s "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&limit=50&minmagnitude=4" > quakes.json
+   ```
+
+2. **Explore the API parameters**:
+   - `minmagnitude` / `maxmagnitude` - Filter by magnitude
+   - `starttime` / `endtime` - Date range (ISO 8601)
+   - `latitude` / `longitude` / `maxradiuskm` - Geographic radius
+   - `limit` - Number of results (max 20000)
+
+3. **API Documentation**: [USGS Earthquake API](https://earthquake.usgs.gov/fdsnws/event/1/)
+
+## Related Functions
+
+- [`haversine`](../functions/geo.md#haversine) - Calculate distance between coordinates
+- [`avg`](../functions/math.md#avg), [`median`](../functions/math.md#median), [`stddev`](../functions/math.md#stddev) - Statistical functions
+- [`from_unixtime`](../functions/datetime.md#from_unixtime) - Convert timestamps
+- [`sort_by`](../functions/standard.md#sort_by), [`min_by`](../functions/standard.md#min_by), [`max_by`](../functions/standard.md#max_by) - Sorting functions

--- a/docs/book/src/examples/datasets/index.md
+++ b/docs/book/src/examples/datasets/index.md
@@ -1,0 +1,93 @@
+# Real-World Datasets
+
+Learn jpx by working with real data from public APIs. Each example includes:
+
+- How to fetch the data
+- Data structure overview
+- Progressive examples from basic to advanced
+- Practical use cases
+
+## Available Datasets
+
+| Dataset | Description | Key Features |
+|---------|-------------|--------------|
+| [USGS Earthquakes](./earthquakes.md) | Real-time seismic data | Geo functions, statistics, filtering |
+| [Nobel Prize API](./nobel-prize.md) | Laureates and prizes | Multilingual data, text processing, dates |
+| [NASA Near Earth Objects](./nasa-neo.md) | Asteroids and comets | Nested data, unit conversions, risk analysis |
+
+## Quick Start
+
+```bash
+# Fetch earthquake data
+curl -s "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&limit=20&minmagnitude=5" > quakes.json
+
+# Try a query
+jpx 'features[*].{mag: properties.mag, place: properties.place}' quakes.json
+```
+
+## What You'll Learn
+
+### Filtering & Selection
+- Complex filter expressions with multiple conditions
+- Nested field access patterns
+- Text-based filtering with `contains`, `starts_with`
+
+### Statistics & Aggregation
+- `avg`, `median`, `stddev` for numeric analysis
+- `min`, `max`, `min_by`, `max_by` for extremes
+- `length` and counting patterns
+
+### Geographic Calculations
+- `haversine` for distance calculations
+- Coordinate extraction and formatting
+- Distance-based sorting
+
+### Date/Time Operations
+- Unix timestamp conversion with `from_unixtime`
+- Date formatting with `format_datetime`
+- Date range filtering
+
+### Data Transformation
+- Reshaping nested structures
+- Flattening for export
+- CSV/TSV output for spreadsheets
+
+### Pipeline Patterns
+- Multi-step transformations
+- Sorting and limiting results
+- Building summary reports
+
+## Tips for Working with APIs
+
+1. **Save data locally** for faster iteration:
+   ```bash
+   curl -s "API_URL" > data.json
+   jpx 'expression' data.json
+   ```
+
+2. **Explore structure first**:
+   ```bash
+   jpx 'keys(@)' data.json          # Top-level keys
+   jpx '@[0]' data.json             # First element (arrays)
+   jpx 'type(@)' data.json          # Data type
+   ```
+
+3. **Use `--compact` for pipelines**:
+   ```bash
+   jpx -c 'expression' data.json | jpx 'next_expression'
+   ```
+
+4. **Export for analysis**:
+   ```bash
+   jpx --csv 'transform' data.json > output.csv
+   ```
+
+## More Data Sources
+
+Looking for more datasets to practice with? Check out:
+
+- [Awesome JSON Datasets](https://github.com/jdorfman/awesome-json-datasets) - Curated list of public JSON APIs
+- [Public APIs](https://github.com/public-apis/public-apis) - Collective list of free APIs
+- [NASA Open APIs](https://api.nasa.gov/) - Space and Earth science data
+- [OpenWeatherMap](https://openweathermap.org/api) - Weather data
+- [GitHub API](https://docs.github.com/en/rest) - Repository and user data

--- a/docs/book/src/examples/datasets/nasa-neo.md
+++ b/docs/book/src/examples/datasets/nasa-neo.md
@@ -1,0 +1,454 @@
+# NASA Near Earth Objects
+
+NASA's [Near Earth Object Web Service](https://api.nasa.gov/) provides data about asteroids and comets that pass close to Earth. This dataset is excellent for learning jpx because it has:
+
+- Deeply nested data structures
+- Multiple unit systems (km, miles, AU, lunar distances)
+- Boolean flags for hazard classification
+- Time series data (close approach dates)
+- Complex orbital mechanics data
+
+## Getting the Data
+
+```bash
+# Browse all NEOs (paginated)
+curl -s "https://api.nasa.gov/neo/rest/v1/neo/browse?api_key=DEMO_KEY" > neo_browse.json
+
+# Get NEOs by close approach date (today)
+curl -s "https://api.nasa.gov/neo/rest/v1/feed?api_key=DEMO_KEY" > neo_feed.json
+
+# Get specific date range
+curl -s "https://api.nasa.gov/neo/rest/v1/feed?start_date=2024-01-01&end_date=2024-01-07&api_key=DEMO_KEY" > neo_week.json
+
+# Look up specific asteroid
+curl -s "https://api.nasa.gov/neo/rest/v1/neo/2000433?api_key=DEMO_KEY" > eros.json
+```
+
+> **Note**: Use `DEMO_KEY` for testing (limited rate). Get a free API key at [api.nasa.gov](https://api.nasa.gov/).
+
+## Data Structure
+
+The browse endpoint returns:
+
+```json
+{
+  "links": {"self": "...", "next": "..."},
+  "page": {
+    "size": 20,
+    "total_elements": 41839,
+    "total_pages": 2092,
+    "number": 0
+  },
+  "near_earth_objects": [
+    {
+      "id": "2000433",
+      "name": "433 Eros (A898 PA)",
+      "name_limited": "Eros",
+      "nasa_jpl_url": "https://ssd.jpl.nasa.gov/...",
+      "absolute_magnitude_h": 10.38,
+      "estimated_diameter": {
+        "kilometers": {"estimated_diameter_min": 22.31, "estimated_diameter_max": 49.89},
+        "meters": {...},
+        "miles": {...},
+        "feet": {...}
+      },
+      "is_potentially_hazardous_asteroid": false,
+      "close_approach_data": [
+        {
+          "close_approach_date": "2024-01-15",
+          "relative_velocity": {
+            "kilometers_per_second": "5.57",
+            "kilometers_per_hour": "20083.02",
+            "miles_per_hour": "12478.81"
+          },
+          "miss_distance": {
+            "astronomical": "0.314",
+            "lunar": "122.5",
+            "kilometers": "47112732",
+            "miles": "29274494"
+          },
+          "orbiting_body": "Earth"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Basic Queries
+
+### List Asteroid Names
+
+```bash
+jpx 'near_earth_objects[*].name' neo_browse.json
+```
+
+### Get Short Names
+
+```bash
+jpx 'near_earth_objects[*].name_limited' neo_browse.json
+```
+
+Output:
+```json
+["Eros", "Albert", "Alinda", "Ganymed", ...]
+```
+
+### Count NEOs in Response
+
+```bash
+jpx 'page.total_elements' neo_browse.json
+```
+
+Output: `41839` (total known NEOs!)
+
+---
+
+## Filtering
+
+### Find Potentially Hazardous Asteroids (PHAs)
+
+```bash
+jpx 'near_earth_objects[?is_potentially_hazardous_asteroid == `true`].{
+  name: name_limited,
+  diameter_km: estimated_diameter.kilometers.estimated_diameter_max
+}' neo_browse.json
+```
+
+### Find Large Asteroids (> 1km)
+
+```bash
+jpx 'near_earth_objects[?estimated_diameter.kilometers.estimated_diameter_max > `1`].{
+  name: name,
+  max_diameter_km: estimated_diameter.kilometers.estimated_diameter_max,
+  hazardous: is_potentially_hazardous_asteroid
+}' neo_browse.json
+```
+
+### Find Non-Hazardous Objects
+
+```bash
+jpx 'near_earth_objects[?is_potentially_hazardous_asteroid == `false`].name_limited' neo_browse.json
+```
+
+---
+
+## Working with Nested Data
+
+### Extract Diameter Estimates
+
+The API provides diameters in multiple units:
+
+```bash
+jpx 'near_earth_objects[*].{
+  name: name_limited,
+  min_km: estimated_diameter.kilometers.estimated_diameter_min,
+  max_km: estimated_diameter.kilometers.estimated_diameter_max
+}' neo_browse.json
+```
+
+### Calculate Average Diameter
+
+```bash
+jpx 'near_earth_objects[*].{
+  name: name_limited,
+  avg_diameter_km: divide(
+    add(
+      estimated_diameter.kilometers.estimated_diameter_min,
+      estimated_diameter.kilometers.estimated_diameter_max
+    ),
+    `2`
+  )
+}' neo_browse.json
+```
+
+### Get Diameter in Different Units
+
+```bash
+jpx 'near_earth_objects[0].{
+  name: name,
+  in_km: estimated_diameter.kilometers,
+  in_meters: estimated_diameter.meters,
+  in_miles: estimated_diameter.miles
+}' neo_browse.json
+```
+
+---
+
+## Close Approach Data
+
+### Get Next Close Approach
+
+```bash
+jpx 'near_earth_objects[*].{
+  name: name_limited,
+  next_approach: close_approach_data[0].close_approach_date,
+  miss_distance_km: close_approach_data[0].miss_distance.kilometers
+}' neo_browse.json
+```
+
+### Find Closest Approaches (in Lunar Distances)
+
+One lunar distance = 384,400 km (distance to the Moon):
+
+```bash
+jpx 'near_earth_objects[*].close_approach_data[*].{
+  asteroid: @.@.@.name_limited,
+  date: close_approach_date,
+  lunar_distances: miss_distance.lunar
+} | flatten(@)' neo_browse.json
+```
+
+### Sort by Miss Distance
+
+```bash
+jpx 'near_earth_objects[*].{
+  name: name_limited,
+  miss_km: to_number(close_approach_data[0].miss_distance.kilometers)
+} | sort_by(@, &miss_km) | [:10]' neo_browse.json
+```
+
+### Find High-Speed Approaches
+
+```bash
+jpx 'near_earth_objects[*].{
+  name: name_limited,
+  speed_kph: to_number(close_approach_data[0].relative_velocity.kilometers_per_hour),
+  date: close_approach_data[0].close_approach_date
+} | [?speed_kph > `50000`]' neo_browse.json
+```
+
+---
+
+## Statistics
+
+### Size Statistics
+
+```bash
+jpx '{
+  count: length(near_earth_objects),
+  smallest_km: min(near_earth_objects[*].estimated_diameter.kilometers.estimated_diameter_min),
+  largest_km: max(near_earth_objects[*].estimated_diameter.kilometers.estimated_diameter_max),
+  avg_max_km: round(avg(near_earth_objects[*].estimated_diameter.kilometers.estimated_diameter_max), `2`)
+}' neo_browse.json
+```
+
+### Hazard Statistics
+
+```bash
+jpx '{
+  total: length(near_earth_objects),
+  hazardous: length(near_earth_objects[?is_potentially_hazardous_asteroid == `true`]),
+  safe: length(near_earth_objects[?is_potentially_hazardous_asteroid == `false`]),
+  hazard_percentage: multiply(
+    divide(
+      length(near_earth_objects[?is_potentially_hazardous_asteroid == `true`]),
+      length(near_earth_objects)
+    ),
+    `100`
+  )
+}' neo_browse.json
+```
+
+### Magnitude Distribution
+
+Absolute magnitude (H) indicates brightness/size:
+
+```bash
+jpx '{
+  magnitudes: near_earth_objects[*].absolute_magnitude_h,
+  min_mag: min(near_earth_objects[*].absolute_magnitude_h),
+  max_mag: max(near_earth_objects[*].absolute_magnitude_h),
+  avg_mag: round(avg(near_earth_objects[*].absolute_magnitude_h), `2`)
+}' neo_browse.json
+```
+
+---
+
+## Sorting and Ranking
+
+### Top 5 Largest Asteroids
+
+```bash
+jpx 'sort_by(near_earth_objects, &estimated_diameter.kilometers.estimated_diameter_max) 
+  | reverse(@) 
+  | [:5] 
+  | [*].{
+      name: name,
+      max_diameter_km: round(estimated_diameter.kilometers.estimated_diameter_max, `2`),
+      hazardous: is_potentially_hazardous_asteroid
+    }' neo_browse.json
+```
+
+### Brightest Objects (Lowest Magnitude)
+
+```bash
+jpx 'sort_by(near_earth_objects, &absolute_magnitude_h) | [:5] | [*].{
+  name: name_limited,
+  magnitude: absolute_magnitude_h,
+  diameter_km: estimated_diameter.kilometers.estimated_diameter_max
+}' neo_browse.json
+```
+
+---
+
+## Unit Conversions
+
+### Convert AU to Kilometers
+
+1 AU (Astronomical Unit) = ~149,597,870.7 km:
+
+```bash
+jpx 'near_earth_objects[*].{
+  name: name_limited,
+  miss_au: to_number(close_approach_data[0].miss_distance.astronomical),
+  miss_km: to_number(close_approach_data[0].miss_distance.kilometers)
+}' neo_browse.json
+```
+
+### Velocity Comparisons
+
+```bash
+jpx 'near_earth_objects[*].{
+  name: name_limited,
+  km_per_sec: to_number(close_approach_data[0].relative_velocity.kilometers_per_second),
+  km_per_hour: to_number(close_approach_data[0].relative_velocity.kilometers_per_hour),
+  mph: to_number(close_approach_data[0].relative_velocity.miles_per_hour)
+}' neo_browse.json
+```
+
+---
+
+## Data Transformation
+
+### Flatten for Analysis
+
+```bash
+jpx 'near_earth_objects[*].{
+  id: id,
+  name: name_limited,
+  magnitude: absolute_magnitude_h,
+  diameter_min_km: estimated_diameter.kilometers.estimated_diameter_min,
+  diameter_max_km: estimated_diameter.kilometers.estimated_diameter_max,
+  is_hazardous: is_potentially_hazardous_asteroid,
+  next_approach_date: close_approach_data[0].close_approach_date,
+  miss_distance_km: close_approach_data[0].miss_distance.kilometers,
+  velocity_kph: close_approach_data[0].relative_velocity.kilometers_per_hour,
+  jpl_url: nasa_jpl_url
+}' neo_browse.json
+```
+
+### Export to CSV
+
+```bash
+jpx --csv 'near_earth_objects[*].{
+  name: name_limited,
+  magnitude: absolute_magnitude_h,
+  max_diameter_km: estimated_diameter.kilometers.estimated_diameter_max,
+  is_hazardous: is_potentially_hazardous_asteroid,
+  approach_date: close_approach_data[0].close_approach_date
+}' neo_browse.json
+```
+
+---
+
+## Advanced Pipelines
+
+### Risk Assessment Report
+
+```bash
+jpx '{
+  report_title: `Near Earth Object Risk Assessment`,
+  total_objects: page.total_elements,
+  sample_size: length(near_earth_objects),
+  potentially_hazardous: {
+    count: length(near_earth_objects[?is_potentially_hazardous_asteroid == `true`]),
+    objects: near_earth_objects[?is_potentially_hazardous_asteroid == `true`] | [*].{
+      name: name,
+      diameter_km: round(estimated_diameter.kilometers.estimated_diameter_max, `2`),
+      next_approach: close_approach_data[0].close_approach_date,
+      miss_lunar: close_approach_data[0].miss_distance.lunar
+    }
+  },
+  largest_objects: sort_by(near_earth_objects, &estimated_diameter.kilometers.estimated_diameter_max) 
+    | reverse(@) 
+    | [:3] 
+    | [*].{name: name_limited, km: round(estimated_diameter.kilometers.estimated_diameter_max, `1`)}
+}' neo_browse.json
+```
+
+### Pipeline: Filter, Sort, Transform
+
+```bash
+jpx 'near_earth_objects
+  | [?estimated_diameter.kilometers.estimated_diameter_max > `0.5`]
+  | [?is_potentially_hazardous_asteroid == `true`]
+  | sort_by(@, &estimated_diameter.kilometers.estimated_diameter_max)
+  | reverse(@)
+  | [*].{
+      name: name,
+      size_category: `LARGE PHA`,
+      diameter_range: concat(
+        to_string(round(estimated_diameter.kilometers.estimated_diameter_min, `1`)),
+        ` - `,
+        to_string(round(estimated_diameter.kilometers.estimated_diameter_max, `1`)),
+        ` km`
+      )
+    }' neo_browse.json
+```
+
+---
+
+## Working with the Feed Endpoint
+
+The feed endpoint returns NEOs by date:
+
+```bash
+curl -s "https://api.nasa.gov/neo/rest/v1/feed?start_date=2024-01-15&end_date=2024-01-16&api_key=DEMO_KEY" > neo_day.json
+```
+
+### Count by Date
+
+```bash
+jpx 'element_count' neo_day.json
+```
+
+### List All Dates with Objects
+
+```bash
+jpx 'keys(near_earth_objects)' neo_day.json
+```
+
+### Get Objects for Specific Date
+
+```bash
+jpx 'near_earth_objects."2024-01-15"[*].name' neo_day.json
+```
+
+---
+
+## Try It Yourself
+
+1. **Get your free API key**: [api.nasa.gov](https://api.nasa.gov/)
+
+2. **Interesting queries to try**:
+   - Find the closest approach ever recorded
+   - List all PHAs larger than 500 meters
+   - Calculate average velocity of approaching objects
+
+3. **API endpoints**:
+   - `/neo/browse` - Paginated list of all NEOs
+   - `/neo/rest/v1/feed` - NEOs by approach date
+   - `/neo/{id}` - Specific asteroid details
+
+4. **API Documentation**: [NASA NEO API](https://api.nasa.gov/)
+
+## Related Functions
+
+- [`sort_by`](../functions/standard.md#sort_by), [`reverse`](../functions/standard.md#reverse) - Sorting and ordering
+- [`to_number`](../functions/standard.md#to_number) - Convert string numbers
+- [`round`](../functions/math.md#round), [`divide`](../functions/math.md#divide), [`multiply`](../functions/math.md#multiply) - Math operations
+- [`avg`](../functions/math.md#avg), [`min`](../functions/standard.md#min), [`max`](../functions/standard.md#max) - Statistics
+- [`flatten`](../functions/array.md#flatten) - Flatten nested arrays

--- a/docs/book/src/examples/datasets/nobel-prize.md
+++ b/docs/book/src/examples/datasets/nobel-prize.md
@@ -1,0 +1,429 @@
+# Nobel Prize Data
+
+The [Nobel Prize API](https://www.nobelprize.org/about/developer-zone-2/) provides comprehensive data about Nobel laureates and prizes. This dataset is excellent for learning jpx because it has:
+
+- Deeply nested multilingual data
+- Rich biographical information
+- Dates and geographic locations
+- Complex relationships (laureates, prizes, affiliations)
+
+## Getting the Data
+
+```bash
+# Fetch laureates (paginated, 25 per page by default)
+curl -s "https://api.nobelprize.org/2.1/laureates?limit=50" > laureates.json
+
+# Fetch all prizes
+curl -s "https://api.nobelprize.org/2.1/nobelPrizes?limit=100" > prizes.json
+
+# Fetch laureates by category
+curl -s "https://api.nobelprize.org/2.1/laureates?nobelPrizeCategory=phy&limit=50" > physics_laureates.json
+```
+
+## Data Structure
+
+The laureates endpoint returns:
+
+```json
+{
+  "laureates": [
+    {
+      "id": "102",
+      "knownName": {"en": "Aage N. Bohr", "se": "Aage N. Bohr"},
+      "givenName": {"en": "Aage N."},
+      "familyName": {"en": "Bohr"},
+      "gender": "male",
+      "birth": {
+        "date": "1922-06-19",
+        "place": {
+          "city": {"en": "Copenhagen"},
+          "country": {"en": "Denmark"},
+          "continent": {"en": "Europe"}
+        }
+      },
+      "death": {
+        "date": "2009-09-08",
+        "place": {...}
+      },
+      "nobelPrizes": [
+        {
+          "awardYear": "1975",
+          "category": {"en": "Physics"},
+          "portion": "1/3",
+          "motivation": {"en": "for the discovery of..."},
+          "prizeAmount": 630000,
+          "affiliations": [...]
+        }
+      ]
+    }
+  ],
+  "meta": {"count": 50, "limit": 50, "offset": 0}
+}
+```
+
+---
+
+## Basic Queries
+
+### List All Laureate Names
+
+```bash
+jpx 'laureates[*].knownName.en' laureates.json
+```
+
+### Get Name and Prize Year
+
+```bash
+jpx 'laureates[*].{
+  name: knownName.en,
+  year: nobelPrizes[0].awardYear,
+  category: nobelPrizes[0].category.en
+}' laureates.json
+```
+
+Output:
+```json
+[
+  {"name": "A. Michael Spence", "year": "2001", "category": "Economic Sciences"},
+  {"name": "Aage N. Bohr", "year": "1975", "category": "Physics"},
+  ...
+]
+```
+
+### Count Laureates
+
+```bash
+jpx 'length(laureates)' laureates.json
+```
+
+---
+
+## Filtering
+
+### Find Physics Laureates
+
+```bash
+jpx 'laureates[?nobelPrizes[0].category.en == `Physics`].knownName.en' laureates.json
+```
+
+### Find Female Laureates
+
+```bash
+jpx 'laureates[?gender == `female`].{
+  name: knownName.en,
+  category: nobelPrizes[0].category.en,
+  year: nobelPrizes[0].awardYear
+}' laureates.json
+```
+
+### Find Living Laureates
+
+```bash
+jpx 'laureates[?death == null].{
+  name: knownName.en,
+  born: birth.date
+}' laureates.json
+```
+
+### Find Laureates Born in a Specific Country
+
+```bash
+jpx 'laureates[?birth.place.country.en == `USA`].{
+  name: knownName.en,
+  city: birth.place.city.en
+}' laureates.json
+```
+
+### Find Multiple Prize Winners
+
+Some laureates have won multiple Nobel Prizes:
+
+```bash
+jpx 'laureates[?length(nobelPrizes) > `1`].{
+  name: knownName.en,
+  prizes: nobelPrizes[*].{
+    year: awardYear,
+    category: category.en
+  }
+}' laureates.json
+```
+
+---
+
+## Working with Multilingual Data
+
+The API provides data in multiple languages (en, se, no):
+
+### Extract English Names
+
+```bash
+jpx 'laureates[*].knownName.en' laureates.json
+```
+
+### Compare Languages
+
+```bash
+jpx 'laureates[:5] | [*].{
+  english: knownName.en,
+  swedish: knownName.se
+}' laureates.json
+```
+
+### Get Motivation in English
+
+```bash
+jpx 'laureates[*].{
+  name: knownName.en,
+  motivation: nobelPrizes[0].motivation.en
+}' laureates.json
+```
+
+---
+
+## Date Operations
+
+### Extract Birth Years
+
+```bash
+jpx 'laureates[*].{
+  name: knownName.en,
+  birth_year: split(birth.date, `-`)[0]
+}' laureates.json
+```
+
+### Calculate Age at Award
+
+```bash
+jpx 'laureates[?birth.date != null].{
+  name: knownName.en,
+  born: split(birth.date, `-`)[0],
+  awarded: nobelPrizes[0].awardYear,
+  age_at_award: subtract(
+    to_number(nobelPrizes[0].awardYear),
+    to_number(split(birth.date, `-`)[0])
+  )
+}' laureates.json
+```
+
+### Find Laureates Born Before 1900
+
+```bash
+jpx 'laureates[?to_number(split(birth.date, `-`)[0]) < `1900`].{
+  name: knownName.en,
+  born: birth.date
+}' laureates.json
+```
+
+---
+
+## Geographic Analysis
+
+### Laureates by Birth Country
+
+```bash
+jpx 'laureates[*].birth.place.country.en' laureates.json | jpx -s 'group_by(@, &@) | @.{
+  country: [0],
+  count: length(@)
+}'
+```
+
+Or using `frequencies`:
+
+```bash
+jpx 'frequencies(laureates[*].birth.place.country.en)' laureates.json
+```
+
+### Laureates by Continent
+
+```bash
+jpx 'laureates[*].{
+  name: knownName.en,
+  continent: birth.place.continent.en
+}' laureates.json
+```
+
+### Extract Coordinates
+
+```bash
+jpx 'laureates[?birth.place.cityNow.latitude != null].{
+  name: knownName.en,
+  city: birth.place.city.en,
+  lat: birth.place.cityNow.latitude,
+  lon: birth.place.cityNow.longitude
+}' laureates.json
+```
+
+---
+
+## Prize Analysis
+
+### Prize Amounts Over Time
+
+```bash
+jpx 'laureates[*].nobelPrizes[0].{
+  year: awardYear,
+  amount: prizeAmount,
+  adjusted: prizeAmountAdjusted
+} | sort_by(@, &year)' laureates.json
+```
+
+### Shared Prizes
+
+The `portion` field shows how the prize was split:
+
+```bash
+jpx 'laureates[?nobelPrizes[0].portion != `1`].{
+  name: knownName.en,
+  portion: nobelPrizes[0].portion,
+  year: nobelPrizes[0].awardYear
+}' laureates.json
+```
+
+### Find Solo Winners
+
+```bash
+jpx 'laureates[?nobelPrizes[0].portion == `1`].{
+  name: knownName.en,
+  category: nobelPrizes[0].category.en,
+  year: nobelPrizes[0].awardYear
+}' laureates.json
+```
+
+---
+
+## Affiliations
+
+### Extract University Affiliations
+
+```bash
+jpx 'laureates[*].{
+  name: knownName.en,
+  university: nobelPrizes[0].affiliations[0].name.en,
+  country: nobelPrizes[0].affiliations[0].country.en
+}' laureates.json
+```
+
+### Find Stanford Affiliates
+
+```bash
+jpx 'laureates[?contains(to_string(nobelPrizes[*].affiliations[*].name.en), `Stanford`)].knownName.en' laureates.json
+```
+
+---
+
+## Text Processing
+
+### Search Motivations
+
+Find laureates whose work involved "quantum":
+
+```bash
+jpx 'laureates[?contains(lower(to_string(nobelPrizes[*].motivation.en)), `quantum`)].{
+  name: knownName.en,
+  motivation: nobelPrizes[0].motivation.en
+}' laureates.json
+```
+
+### Extract Key Terms from Motivations
+
+```bash
+jpx 'laureates[*].nobelPrizes[0].motivation.en' laureates.json
+```
+
+---
+
+## Data Transformation
+
+### Flatten for Export
+
+```bash
+jpx 'laureates[*].{
+  id: id,
+  name: knownName.en,
+  gender: gender,
+  birth_date: birth.date,
+  birth_country: birth.place.country.en,
+  death_date: death.date,
+  prize_year: nobelPrizes[0].awardYear,
+  prize_category: nobelPrizes[0].category.en,
+  prize_portion: nobelPrizes[0].portion,
+  motivation: nobelPrizes[0].motivation.en
+}' laureates.json
+```
+
+### Export to CSV
+
+```bash
+jpx --csv 'laureates[*].{
+  name: knownName.en,
+  year: nobelPrizes[0].awardYear,
+  category: nobelPrizes[0].category.en,
+  country: birth.place.country.en
+}' laureates.json
+```
+
+---
+
+## Advanced Pipelines
+
+### Summary by Category
+
+```bash
+jpx '{
+  physics: length(laureates[?nobelPrizes[0].category.en == `Physics`]),
+  chemistry: length(laureates[?nobelPrizes[0].category.en == `Chemistry`]),
+  medicine: length(laureates[?contains(nobelPrizes[0].category.en, `Medicine`) || contains(nobelPrizes[0].category.en, `Physiology`)]),
+  literature: length(laureates[?nobelPrizes[0].category.en == `Literature`]),
+  peace: length(laureates[?nobelPrizes[0].category.en == `Peace`]),
+  economics: length(laureates[?contains(nobelPrizes[0].category.en, `Economic`)])
+}' laureates.json
+```
+
+### Gender Distribution by Decade
+
+```bash
+jpx 'laureates[*].{
+  decade: concat(slice(nobelPrizes[0].awardYear, `0`, `3`), `0s`),
+  gender: gender
+}' laureates.json
+```
+
+### Youngest and Oldest Winners
+
+```bash
+jpx '{
+  dataset: laureates[?birth.date != null] | [*].{
+    name: knownName.en,
+    age: subtract(to_number(nobelPrizes[0].awardYear), to_number(split(birth.date, `-`)[0]))
+  },
+  youngest: min_by(@.dataset, &age),
+  oldest: max_by(@.dataset, &age)
+}' laureates.json
+```
+
+---
+
+## Try It Yourself
+
+1. **Explore the API**:
+   ```bash
+   # All laureates (paginated)
+   curl -s "https://api.nobelprize.org/2.1/laureates?limit=100&offset=0"
+   
+   # Filter by category
+   curl -s "https://api.nobelprize.org/2.1/laureates?nobelPrizeCategory=lit"
+   
+   # Filter by year
+   curl -s "https://api.nobelprize.org/2.1/nobelPrizes?nobelPrizeYear=2023"
+   ```
+
+2. **Category codes**: `phy` (Physics), `che` (Chemistry), `med` (Medicine), `lit` (Literature), `pea` (Peace), `eco` (Economics)
+
+3. **API Documentation**: [Nobel Prize API](https://www.nobelprize.org/about/developer-zone-2/)
+
+## Related Functions
+
+- [`contains`](../functions/standard.md#contains), [`starts_with`](../functions/standard.md#starts_with) - Text matching
+- [`split`](../functions/string.md#split), [`lower`](../functions/string.md#lower) - String manipulation
+- [`group_by`](../functions/array.md#group_by), [`frequencies`](../functions/array.md#frequencies) - Aggregation
+- [`to_number`](../functions/standard.md#to_number), [`subtract`](../functions/math.md#subtract) - Calculations


### PR DESCRIPTION
## Summary

Add comprehensive example documentation using three public APIs to help users learn jpx with real data.

## Datasets

### 1. USGS Earthquakes
- Real-time seismic data from the USGS API
- Showcases: geo functions (`haversine`), statistics (`avg`, `median`, `stddev`), filtering, date/time operations
- GeoJSON structure with coordinates and magnitudes

### 2. Nobel Prize API  
- Laureates and prize data with multilingual support
- Showcases: text processing, nested data access, date calculations, aggregation
- Rich biographical and institutional data

### 3. NASA Near Earth Objects
- Asteroid and comet data from NASA's NEO API
- Showcases: deeply nested structures, unit conversions, boolean filtering, risk analysis
- Multiple measurement systems (km, miles, AU, lunar distances)

## Structure

Each page includes:
- **Getting the Data** - curl commands to fetch sample data
- **Data Structure** - JSON schema overview
- **Basic Queries** - Simple extraction and filtering
- **Advanced Pipelines** - Multi-step transformations
- **Statistics & Aggregation** - Numeric analysis
- **Export** - CSV/TSV output examples
- **Related Functions** - Links to relevant function docs

## Preview

Example from earthquake docs:
```bash
# Find major earthquakes and calculate distance from San Francisco
jpx 'features[?properties.mag >= `6`] | [*].{
  place: properties.place,
  magnitude: properties.mag,
  distance_km: round(haversine(`37.7749`, `-122.4194`, 
    geometry.coordinates[1], geometry.coordinates[0]), `0`)
}' earthquakes.json
```

Partial implementation of #268 - more datasets can be added later.