### PR TITLE
fix(cli): prefix all error messages with 'jpx:'

### DIFF
--- a/jpx/src/main.rs
+++ b/jpx/src/main.rs
@@ -266,7 +266,14 @@ struct Args {
     warmup: u32,
 }
 
-fn main() -> Result<()> {
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("jpx: {err:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     let mut args = Args::parse();
     apply_env_defaults(&mut args);
 


### PR DESCRIPTION
## Summary

Add consistent `jpx: ` prefix to all error messages for clarity in pipelines.

## Changes

Wrap `main()` in a `run()` function that handles errors with a consistent prefix.

## Before

```
Error: Failed to parse JSON input: expected ident at line 1 column 2
```

## After

```
jpx: Failed to parse JSON input: expected ident at line 1 column 2
```

## Examples

```bash
$ jpx 'invalid[' <<<'{}'
jpx: Failed to compile expression: invalid[: Parse error: ...

$ jpx -f nonexistent.json '@'
jpx: Failed to read file: nonexistent.json: No such file or directory (os error 2)

$ echo 'not json' | jpx '@'
jpx: Failed to parse JSON input: expected ident at line 1 column 2
```

Closes #273