### PR TITLE
feat(cli): add --debug flag for diagnostic information

### DIFF
--- a/jpx/src/main.rs
+++ b/jpx/src/main.rs
@@ -233,6 +233,10 @@ struct Args {
     #[arg(long)]
     explain: bool,
 
+    /// Show diagnostic information for troubleshooting
+    #[arg(long)]
+    debug: bool,
+
     /// Start interactive REPL mode
     #[arg(long)]
     repl: bool,
@@ -316,6 +320,75 @@ fn main() -> Result<()> {
     if let Some(func_name) = &args.similar {
         find_similar_functions(&registry, func_name)?;
         return Ok(());
+    }
+
+    // Debug mode: show diagnostic information
+    if args.debug {
+        eprintln!("{}", "=== jpx debug info ===".cyan().bold());
+        eprintln!("{}: {}", "Version".dimmed(), env!("CARGO_PKG_VERSION"));
+        eprintln!();
+
+        // Show environment variables
+        eprintln!("{}:", "Environment".cyan());
+        for (var, desc) in [
+            ("JPX_VERBOSE", "verbose mode"),
+            ("JPX_QUIET", "quiet mode"),
+            ("JPX_STRICT", "strict mode"),
+            ("JPX_RAW", "raw output"),
+            ("JPX_COMPACT", "compact output"),
+        ] {
+            let value = std::env::var(var).unwrap_or_else(|_| "(not set)".to_string());
+            eprintln!("  {} = {} ({})", var, value.yellow(), desc);
+        }
+        eprintln!();
+
+        // Show effective settings
+        eprintln!("{}:", "Effective settings".cyan());
+        eprintln!("  verbose: {}", args.verbose);
+        eprintln!("  quiet: {}", args.quiet);
+        eprintln!("  strict: {}", args.strict);
+        eprintln!("  raw: {}", args.raw);
+        eprintln!("  compact: {}", args.compact);
+        eprintln!();
+
+        // Show input source
+        eprintln!("{}:", "Input".cyan());
+        match &args.file {
+            Some(path) => eprintln!("  source: file ({})", path),
+            None if args.null_input => eprintln!("  source: null (--null-input)"),
+            None => eprintln!("  source: stdin"),
+        }
+        if args.slurp {
+            eprintln!("  mode: slurp (multiple JSON values)");
+        }
+        eprintln!();
+
+        // Show expressions
+        let debug_expressions: Vec<&String> = args
+            .expressions
+            .iter()
+            .chain(args.positional_expressions.iter())
+            .collect();
+        eprintln!("{}:", "Expressions".cyan());
+        if debug_expressions.is_empty() {
+            eprintln!("  (none provided - will use '@')");
+        } else {
+            for (i, expr) in debug_expressions.iter().enumerate() {
+                eprintln!("  [{}] {}", i + 1, expr.yellow());
+            }
+        }
+        eprintln!();
+
+        // Show registered functions count
+        eprintln!("{}:", "Functions".cyan());
+        eprintln!("  registered: {}", registry.len());
+        if args.strict {
+            eprintln!("  mode: strict (standard JMESPath only)");
+        } else {
+            eprintln!("  mode: extended (all functions available)");
+        }
+        eprintln!("{}", "======================".cyan().bold());
+        eprintln!();
     }
 
     // Handle --diff: generate JSON Patch from two files


### PR DESCRIPTION
## Summary

Adds a `--debug` flag that displays useful troubleshooting information to help users diagnose issues.

## What's Displayed

```
=== jpx debug info ===
Version: 0.1.15

Environment:
  JPX_VERBOSE = (not set) (verbose mode)
  JPX_QUIET = (not set) (quiet mode)
  JPX_STRICT = (not set) (strict mode)
  JPX_RAW = (not set) (raw output)
  JPX_COMPACT = (not set) (compact output)

Effective settings:
  verbose: false
  quiet: false
  strict: false
  raw: false
  compact: false

Input:
  source: stdin

Expressions:
  [1] keys(@)

Functions:
  registered: 392
  mode: extended (all functions available)
======================
```

## Features

- **Version**: Shows jpx version
- **Environment variables**: Lists all JPX_* environment variables and their current values
- **Effective settings**: Shows what's actually enabled (from any source - env or CLI flags)
- **Input source**: Shows whether reading from stdin or a file (with path)
- **Expressions**: Lists all expressions being evaluated
- **Functions**: Shows count of registered functions and mode (extended vs strict)

## Testing

```bash
# Basic usage
echo '{"a":1}' | jpx --debug 'a'

# With environment variables
JPX_VERBOSE=1 jpx --debug -f data.json 'keys(@)'

# With strict mode
jpx --debug --strict -n 'length("test")'
```

Closes #274