### PR TITLE
feat(cli): add config file support with TOML

### DIFF
--- a/jpx/src/main.rs
+++ b/jpx/src/main.rs
@@ -10,9 +10,11 @@ use jmespath::ast::Ast;
 use jmespath::{Runtime, Variable};
 use jmespath_extensions::register_all;
 use jmespath_extensions::registry::{Category, FunctionInfo, FunctionRegistry};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{self, Read, Write};
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Instant;
 
@@ -22,6 +24,99 @@ const STYLES: styling::Styles = styling::Styles::styled()
     .usage(styling::AnsiColor::Green.on_default().bold())
     .literal(styling::AnsiColor::Cyan.on_default().bold())
     .placeholder(styling::AnsiColor::Cyan.on_default());
+
+// =============================================================================
+// Configuration File Support
+// =============================================================================
+
+/// Configuration file structure
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct Config {
+    /// Output settings
+    verbose: Option<bool>,
+    quiet: Option<bool>,
+    strict: Option<bool>,
+    raw: Option<bool>,
+    compact: Option<bool>,
+    /// Color mode (auto, always, never)
+    color: Option<String>,
+}
+
+/// Get the path to the config file
+fn get_config_path() -> Option<PathBuf> {
+    // Check JPX_CONFIG environment variable first
+    if let Ok(path) = std::env::var("JPX_CONFIG") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    // Check ~/.config/jpx/config.toml (XDG style)
+    if let Some(config_dir) = dirs::config_dir() {
+        let path = config_dir.join("jpx").join("config.toml");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    // Check ~/.jpxrc (traditional style)
+    if let Some(home_dir) = dirs::home_dir() {
+        let path = home_dir.join(".jpxrc");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+/// Load configuration from file
+fn load_config() -> Config {
+    let Some(path) = get_config_path() else {
+        return Config::default();
+    };
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Config::default(),
+    };
+
+    match toml::from_str(&content) {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!(
+                "{}: Failed to parse config file {}: {}",
+                "warning".yellow(),
+                path.display(),
+                e
+            );
+            Config::default()
+        }
+    }
+}
+
+/// Apply config file defaults to args (lowest priority)
+fn apply_config_defaults(args: &mut Args, config: &Config) {
+    // Only apply config values if CLI flag wasn't explicitly set
+    // Config has lowest priority: config < env var < CLI flag
+    if !args.verbose && config.verbose == Some(true) {
+        args.verbose = true;
+    }
+    if !args.quiet && config.quiet == Some(true) {
+        args.quiet = true;
+    }
+    if !args.strict && config.strict == Some(true) {
+        args.strict = true;
+    }
+    if !args.raw && config.raw == Some(true) {
+        args.raw = true;
+    }
+    if !args.compact && config.compact == Some(true) {
+        args.compact = true;
+    }
+}
 
 /// Check if an environment variable is set to a "truthy" value
 fn env_is_true(var: &str) -> bool {
@@ -268,6 +363,10 @@ struct Args {
 
 fn main() -> Result<()> {
     let mut args = Args::parse();
+
+    // Load config and apply defaults (priority: config < env var < CLI flag)
+    let config = load_config();
+    apply_config_defaults(&mut args, &config);
     apply_env_defaults(&mut args);
 
     // Handle subcommands


### PR DESCRIPTION
## Summary

Adds support for configuration files to persist default settings, following the priority hierarchy: config file < environment variable < CLI flag.

## Config File Locations

jpx looks for config files in this order:
1. `JPX_CONFIG` environment variable (explicit path)
2. `~/.config/jpx/config.toml` (XDG-style)
3. `~/.jpxrc` (traditional style)

## Supported Options

```toml
# Example ~/.config/jpx/config.toml

# Output verbosity
verbose = false
quiet = false

# Formatting
raw = false
compact = true

# Function mode
strict = false

# Color output (auto, always, never)
color = "auto"
```

## Priority Hierarchy

Settings are applied in order of increasing priority:
1. **Config file** (lowest) - persistent defaults
2. **Environment variables** - session/script overrides
3. **CLI flags** (highest) - one-time overrides

Example:
```bash
# Config file sets compact = true
# Env var is not set
# CLI doesn't specify --compact
# Result: compact output

# Config file sets compact = true  
# JPX_COMPACT=0 overrides to false
# Result: pretty output

# Config file sets compact = true
# CLI passes explicit flag
# Result: whatever the CLI says wins
```

## Testing

```bash
# Create a test config
cat > /tmp/jpx.toml << 'EOF'
verbose = true
compact = true
EOF

# Use it
echo '{"a":1}' | JPX_CONFIG=/tmp/jpx.toml jpx 'keys(@)'
```

Closes #275