### PR TITLE
docs: acknowledge JMESPath project, jmespath.rs, and jp CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,79 @@ See the [jpx README](jpx/README.md) for details.
 
 ---
 
-## Built on jmespath.rs
+## Acknowledgments
+
+### JMESPath
+
+[JMESPath](https://jmespath.org/) is a query language for JSON, created by [James Saryerwinnie](https://github.com/jamesls). The specification, tutorials, and compliance test suite are maintained by the JMESPath community. We're grateful for this well-designed, portable query language that serves as our foundation.
+
+- **Specification**: [jmespath.org](https://jmespath.org/)
+- **GitHub**: [jmespath/jmespath.spec](https://github.com/jmespath/jmespath.spec)
+- **Community**: [jmespath-community](https://github.com/jmespath-community)
+
+### jmespath.rs
 
 This crate extends the [`jmespath`](https://crates.io/crates/jmespath) crate by [@mtdowling](https://github.com/mtdowling), which provides the complete Rust implementation of the [JMESPath specification](https://jmespath.org/specification.html). All spec-compliant parsing, evaluation, and the 26 built-in functions come from that foundational library—we simply add extra functions on top.
 
 **If you only need standard JMESPath functionality, use [`jmespath`](https://crates.io/crates/jmespath) directly.**
+
+### jp - The Official JMESPath CLI
+
+The official [jp](https://github.com/jmespath/jp) CLI tool (written in Go) is a minimal, focused implementation of a JMESPath command-line interface. If you need a lightweight tool that works with standard JMESPath and don't require the extended functions that jpx provides, jp is an excellent choice.
+
+```bash
+# Install jp via Homebrew
+brew install jmespath/jmespath/jp
+```
+
+jpx is inspired by jp's simplicity while extending it with 320+ additional functions and features like multiple output formats, expression pipelines, and interactive REPL mode.
+
+---
+
+## jpx vs jq
+
+[jq](https://jqlang.org/) is the most popular JSON command-line tool. Here's how jpx compares:
+
+| Aspect | jq | jpx |
+|--------|-----|-----|
+| **Language** | Custom DSL (Turing-complete) | JMESPath (standardized query language) |
+| **Learning curve** | Steeper (unique syntax) | Gentler (declarative, function-based) |
+| **Functions** | ~70 built-in | 320+ (string, math, date, geo, hash, etc.) |
+| **Ecosystem** | Standalone | JMESPath works in AWS CLI, Ansible, many languages |
+| **Streaming** | Yes (`--stream`) | No (loads full document) |
+| **Custom functions** | Yes (`def`) | No (fixed function set) |
+
+### Syntax Comparison
+
+```bash
+# Filtering - jq uses select(), jpx uses [?]
+jq '[.[] | select(.age > 30)]' data.json
+jpx '[?age > `30`]' data.json
+
+# Projection - similar but jpx uses [*]
+jq '[.[].name]' data.json
+jpx '[*].name' data.json
+
+# String manipulation
+jq '.name | ascii_upcase' data.json
+jpx 'upper(name)' data.json
+```
+
+### When to Choose jpx
+
+- **Extended functions**: 320+ functions including geo, hashing, fuzzy matching, semver, validation
+- **JMESPath compatibility**: Queries work in AWS CLI (`--query`), Ansible, and other tools
+- **Multiple output formats**: JSON, YAML, TOML, CSV, TSV, table
+- **AI integration**: MCP server for Claude and other assistants
+- **Function discovery**: `--search`, `--describe`, `--similar` to explore available functions
+
+### When to Choose jq
+
+- **Complex transformations**: Recursive functions, variable bindings, custom function definitions
+- **Streaming**: Process very large files without loading into memory
+- **Team familiarity**: If your team already knows jq well
+
+**[Full comparison guide →](https://joshrotenberg.github.io/jmespath-extensions/examples/jq-comparison.html)**
 
 ---
 

--- a/jpx/README.md
+++ b/jpx/README.md
@@ -6,7 +6,39 @@
 
 A command-line tool for querying JSON data using JMESPath expressions with 320+ additional functions beyond the standard JMESPath specification.
 
-Built on the [`jmespath`](https://crates.io/crates/jmespath) crate by [@mtdowling](https://github.com/mtdowling), which provides the complete Rust implementation of the [JMESPath specification](https://jmespath.org/specification.html) including parsing, evaluation, and all 26 standard built-in functions.
+## Acknowledgments
+
+jpx builds on the excellent work of the JMESPath community:
+
+- **[JMESPath](https://jmespath.org/)** - The query language specification created by [James Saryerwinnie](https://github.com/jamesls)
+- **[jmespath.rs](https://crates.io/crates/jmespath)** - The Rust implementation by [@mtdowling](https://github.com/mtdowling) that provides our parsing, evaluation, and standard functions
+- **[jp](https://github.com/jmespath/jp)** - The official JMESPath CLI (Go) - a minimal, focused tool that inspired jpx's design
+
+If you only need standard JMESPath without extensions, consider using [jp](https://github.com/jmespath/jp) or the [`jmespath`](https://crates.io/crates/jmespath) crate directly.
+
+## jpx vs jq
+
+Coming from [jq](https://jqlang.org/)? Here's a quick comparison:
+
+| | jq | jpx |
+|---|-----|-----|
+| **Language** | Custom DSL | JMESPath (standardized) |
+| **Functions** | ~70 built-in | 320+ extensions |
+| **Ecosystem** | Standalone | Works with AWS CLI, Ansible |
+| **Streaming** | ✅ | ❌ |
+
+```bash
+# jq                                    # jpx
+jq '[.[] | select(.age > 30)]'          jpx '[?age > `30`]'
+jq '.[].name'                           jpx '[*].name'
+jq '.name | ascii_upcase'               jpx 'upper(name)'
+```
+
+**Choose jpx** for: extended functions (geo, hash, fuzzy, semver), multiple output formats, AI/MCP integration, JMESPath ecosystem compatibility.
+
+**Choose jq** for: streaming large files, custom function definitions, complex recursive transformations.
+
+**[Full comparison →](https://joshrotenberg.github.io/jmespath-extensions/examples/jq-comparison.html)**
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Adds proper acknowledgments and jq comparison to both README files.

## What's Added

### Acknowledgments

Credits the foundational work this project builds on:

- **JMESPath** - The query language specification and James Saryerwinnie as the creator
- **jmespath.rs** - @mtdowling's Rust implementation that provides parsing, evaluation, and standard functions
- **jp** - The official JMESPath CLI tool (Go) as a minimal alternative

### jq Comparison

Helps users coming from jq understand the differences:

| | jq | jpx |
|---|-----|-----|
| **Language** | Custom DSL | JMESPath (standardized) |
| **Functions** | ~70 built-in | 320+ extensions |
| **Ecosystem** | Standalone | Works with AWS CLI, Ansible |
| **Streaming** | ✅ | ❌ |

Includes:
- Syntax comparison examples (filtering, projection, string manipulation)
- When to choose jpx (extended functions, output formats, AI/MCP, JMESPath ecosystem)
- When to choose jq (streaming, custom functions, complex transformations)
- Link to full comparison guide in the docs

## Why

- Gives credit where credit is due
- Helps jq users evaluate whether jpx fits their needs
- Important for adoption - jq is the dominant tool, so clear positioning helps users decide