### PR TITLE
docs: remove placeholder examples, reorganize structure

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Working with Files](./guide/working-with-files.md)
 - [Query Files](./guide/query-files.md)
 - [Strict Mode](./guide/strict-mode.md)
+- [jq Comparison](./examples/jq-comparison.md)
 
 # MCP Server
 
@@ -66,13 +67,6 @@
 - [API Reference](./python/api.md)
 
 # Examples
-
-- [Data Transformation](./examples/data-transformation.md)
-- [Log Processing](./examples/log-processing.md)
-- [API Response Handling](./examples/api-responses.md)
-- [jq Comparison](./examples/jq-comparison.md)
-
-# Real-World Datasets
 
 - [Overview](./examples/datasets/index.md)
 - [USGS Earthquakes](./examples/datasets/earthquakes.md)

--- a/docs/book/src/examples/api-responses.md
+++ b/docs/book/src/examples/api-responses.md
@@ -1,4 +1,0 @@
-# api responses
-
-Coming soon.
-

--- a/docs/book/src/examples/data-transformation.md
+++ b/docs/book/src/examples/data-transformation.md
@@ -1,4 +1,0 @@
-# data transformation
-
-Coming soon.
-

--- a/docs/book/src/examples/log-processing.md
+++ b/docs/book/src/examples/log-processing.md
@@ -1,4 +1,0 @@
-# log processing
-
-Coming soon.
-


### PR DESCRIPTION
- Remove 'Coming soon' placeholder files (data-transformation, log-processing, api-responses)
- Move jq Comparison to User Guide section (it's reference material)
- Consolidate Examples section to use Real-World Datasets
- Simplifies navigation and removes unfulfilled promises