### PR TITLE
docs: add multi-server discovery documentation and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# Agent Guidelines for jpx
+
+This document provides guidance for AI agents using jpx as an MCP server.
+
+## Overview
+
+jpx is a JMESPath processor with 360+ extension functions. As an MCP server, it provides tools for:
+
+- Querying and transforming JSON data
+- Discovering JMESPath functions
+- Semantic search across multiple MCP servers
+
+## Quick Start
+
+### JSON Queries
+
+Use `evaluate` for JMESPath queries:
+
+```
+mcp__jpx__evaluate({
+  expression: "users[?active].name",
+  json: {"users": [...]}
+})
+```
+
+### Finding Functions
+
+Use `search` to find relevant functions:
+
+```
+mcp__jpx__search({ query: "string padding" })
+```
+
+Use `describe` for detailed documentation:
+
+```
+mcp__jpx__describe({ function: "pad_left" })
+```
+
+## Multi-Server Tool Discovery
+
+When connected to jpx alongside other MCP servers (e.g., redisctl, github-mcp), you can enable semantic search across all tools.
+
+### Registration Pattern
+
+At session start, register each server's tools with jpx:
+
+```
+// For each non-jpx MCP server:
+mcp__jpx__register_discovery({
+  spec: {
+    server: { name: "server-name", version: "1.0.0" },
+    tools: [
+      { 
+        name: "tool_name", 
+        description: "What this tool does",
+        category: "optional-category",
+        tags: ["optional", "tags"]
+      }
+      // ... more tools
+    ]
+  }
+})
+```
+
+### Searching
+
+After registration, use semantic search:
+
+```
+// Natural language search
+mcp__jpx__query_tools({ query: "backup database", top_k: 5 })
+
+// Find similar tools
+mcp__jpx__similar_tools({ tool_id: "server:tool_name", top_k: 5 })
+
+// Browse by category
+mcp__jpx__list_discovery_categories()
+```
+
+### Recommended System Prompt Addition
+
+Add this to your agent configuration for automatic discovery:
+
+```markdown
+## MCP Tool Discovery
+
+At session start, if jpx and other MCP servers are connected:
+
+1. For each non-jpx MCP server, register its tools with jpx:
+   - Extract tool name, description, and input schema from each tool
+   - Call `mcp__jpx__register_discovery` with the server name and tool list
+   - Include category and tags if available for better search results
+
+2. When searching for tools to accomplish a task:
+   - Use `mcp__jpx__query_tools` for semantic search instead of scanning manually
+   - Use `mcp__jpx__similar_tools` to find alternatives when exploring options
+
+3. The registry is session-scoped - re-register if reconnecting.
+```
+
+## Best Practices
+
+### Analyzing Unknown JSON
+
+Before writing complex queries, understand the data:
+
+1. `stats` - Get structure overview (type, depth, field analysis)
+2. `paths` - See all available paths in dot notation
+3. `keys` - List object keys (use `recursive: true` for nested)
+
+### Building Queries Incrementally
+
+1. `validate` - Check syntax before executing
+2. `evaluate` - Run and check results
+3. `batch_evaluate` - Run multiple queries at once
+
+### JSON Manipulation
+
+For modifications, use RFC-standard tools:
+
+- `diff` - Generate patch between two documents (RFC 6902)
+- `patch` - Apply patch operations (RFC 6902)
+- `merge` - Apply merge patch (RFC 7396)
+
+## Tool Categories
+
+| Category | Tools | Purpose |
+|----------|-------|---------|
+| Function Discovery | search, similar, functions, describe, categories | Find JMESPath functions |
+| Data Analysis | stats, paths, keys | Understand JSON structure |
+| Query Execution | evaluate, evaluate_file, batch_evaluate, validate | Run JMESPath expressions |
+| JSON Utilities | format, diff, patch, merge | Manipulate JSON documents |
+| Multi-Server Discovery | register_discovery, query_tools, similar_tools, list_discovery_servers, list_discovery_categories, inspect_discovery_index, unregister_discovery, get_discovery_schema | Search across MCP servers |

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -23,6 +23,7 @@
 - [Overview](./mcp/overview.md)
 - [Setup with Claude](./mcp/setup-claude.md)
 - [Available Tools](./mcp/tools.md)
+- [Multi-Server Discovery](./mcp/discovery.md)
 - [Examples](./mcp/examples.md)
 
 # Function Reference

--- a/docs/book/src/mcp/discovery.md
+++ b/docs/book/src/mcp/discovery.md
@@ -1,0 +1,291 @@
+# Multi-Server Tool Discovery
+
+jpx provides BM25-based semantic search for discovering tools across multiple MCP servers. This enables natural language queries like "how do I backup a database?" instead of scanning flat tool lists.
+
+## The Problem
+
+When an agent connects to multiple MCP servers, it has access to dozens or hundreds of tools. Finding the right tool for a task means:
+
+- Scanning tool names hoping for a match
+- Reading descriptions one by one
+- Missing tools with different terminology ("backup" vs "snapshot" vs "export")
+
+## The Solution: Registration + Search
+
+jpx provides a discovery registry that indexes tools from any MCP server using BM25 (the algorithm behind search engines). The workflow:
+
+1. **Register**: Agent registers each server's tools with jpx
+2. **Search**: Agent queries across all registered tools semantically
+3. **Discover**: BM25 finds relevant tools even with different wording
+
+## Architecture
+
+MCP servers don't communicate with each other - they only respond to the agent. The agent orchestrates registration:
+
+```
+┌─────────┐     ┌─────────────┐     ┌─────────────┐
+│  Agent  │────▶│     jpx     │     │  redisctl   │
+│         │────▶│  (registry) │     │  (65 tools) │
+│         │────▶│             │     └─────────────┘
+│         │     └─────────────┘     ┌─────────────┐
+│         │────────────────────────▶│ other-mcp   │
+│         │                         │  (N tools)  │
+└─────────┘                         └─────────────┘
+     │
+     │  1. Connect to all servers
+     │  2. Get tool metadata from each
+     │  3. Register with jpx
+     │  4. Query jpx for tool discovery
+     ▼
+```
+
+## Discovery Tools
+
+### Registration
+
+| Tool | Description |
+|------|-------------|
+| `register_discovery` | Register an MCP server's tools |
+| `unregister_discovery` | Remove a server from the registry |
+| `get_discovery_schema` | Get the registration schema |
+
+### Search
+
+| Tool | Description |
+|------|-------------|
+| `query_tools` | BM25 semantic search across all registered tools |
+| `similar_tools` | Find tools related to a specific tool |
+
+### Browse
+
+| Tool | Description |
+|------|-------------|
+| `list_discovery_servers` | List all registered servers |
+| `list_discovery_categories` | List tool categories across servers |
+| `inspect_discovery_index` | Debug index statistics |
+
+## Registration Schema
+
+Register a server's tools with `register_discovery`:
+
+```json
+{
+  "spec": {
+    "server": {
+      "name": "redisctl",
+      "version": "0.1.0",
+      "description": "Redis management tools"
+    },
+    "tools": [
+      {
+        "name": "enterprise_database_create",
+        "description": "Create a new Redis Enterprise database with specified configuration",
+        "category": "enterprise",
+        "subcategory": "database",
+        "tags": ["database", "create", "write"],
+        "examples": ["Create a 500MB database named 'cache'"]
+      },
+      {
+        "name": "enterprise_database_backup",
+        "description": "Trigger a backup snapshot of a Redis Enterprise database",
+        "category": "enterprise",
+        "subcategory": "database",
+        "tags": ["database", "backup", "snapshot", "read"]
+      }
+    ],
+    "categories": {
+      "enterprise": {
+        "description": "Redis Enterprise on-premises tools",
+        "tool_count": 30
+      }
+    }
+  },
+  "replace": false
+}
+```
+
+### Minimal Schema
+
+Only `server.name` and `tools[].name` are required:
+
+```json
+{
+  "spec": {
+    "server": { "name": "myserver" },
+    "tools": [
+      { "name": "tool_one" },
+      { "name": "tool_two" }
+    ]
+  }
+}
+```
+
+### Full Schema
+
+For best search results, include rich metadata:
+
+- `description`: Natural language description (indexed for search)
+- `category` / `subcategory`: For browsing and filtering
+- `tags`: Keywords that improve search relevance
+- `examples`: Usage examples (indexed for search)
+- `inputSchema`: Parameter documentation
+
+## Searching
+
+### Semantic Search
+
+```json
+// query_tools
+{
+  "query": "backup database",
+  "top_k": 5
+}
+```
+
+Returns ranked results with scores:
+
+```json
+[
+  {
+    "tool_id": "redisctl:enterprise_database_backup",
+    "server": "redisctl",
+    "name": "enterprise_database_backup",
+    "description": "Trigger a backup snapshot of a Redis Enterprise database",
+    "score": 8.42,
+    "category": "enterprise"
+  },
+  {
+    "tool_id": "redisctl:enterprise_database_export",
+    "server": "redisctl",
+    "name": "enterprise_database_export",
+    "description": "Export database data to RDB file",
+    "score": 5.17,
+    "category": "enterprise"
+  }
+]
+```
+
+### Similar Tools
+
+Find tools related to one you know:
+
+```json
+// similar_tools
+{
+  "tool_id": "redisctl:enterprise_database_delete",
+  "top_k": 5
+}
+```
+
+Returns tools with similar descriptions/tags - useful for finding alternatives or related operations.
+
+## Agent Workflow
+
+### Manual Registration
+
+At session start, register each server:
+
+```
+1. Get tool list from redisctl (agent already has this via MCP)
+2. Call jpx.register_discovery with redisctl's tools
+3. Repeat for other MCP servers
+4. Use query_tools for semantic search
+```
+
+### Automatic Registration (Recommended)
+
+Add to your agent's system prompt or CLAUDE.md:
+
+```markdown
+## MCP Tool Discovery
+
+At session start, if jpx and other MCP servers are available:
+
+1. For each non-jpx MCP server, register its tools with jpx:
+   - Extract tool name, description, and input schema
+   - Call `mcp__jpx__register_discovery` with the server name and tool list
+
+2. When searching for tools, use `mcp__jpx__query_tools` for semantic search
+   instead of scanning the tool list manually.
+
+3. Use `mcp__jpx__similar_tools` to find related tools when exploring options.
+```
+
+## Example: Multi-Server Setup
+
+With jpx + redisctl + github-mcp:
+
+```
+// Register redisctl (65 tools)
+register_discovery({
+  spec: {
+    server: { name: "redisctl", version: "0.1.0" },
+    tools: [
+      { name: "enterprise_database_create", description: "...", category: "enterprise" },
+      { name: "enterprise_database_backup", description: "...", category: "enterprise" },
+      // ... 63 more tools
+    ]
+  }
+})
+
+// Register github-mcp (20 tools)
+register_discovery({
+  spec: {
+    server: { name: "github", version: "1.0.0" },
+    tools: [
+      { name: "create_issue", description: "Create a GitHub issue", category: "issues" },
+      { name: "list_pull_requests", description: "List PRs for a repo", category: "pulls" },
+      // ... 18 more tools
+    ]
+  }
+})
+
+// Now search across both!
+query_tools({ query: "create new resource", top_k: 10 })
+// Returns: enterprise_database_create, create_issue, enterprise_crdb_create, ...
+```
+
+## BM25 Scoring
+
+The search uses BM25, a proven ranking algorithm that:
+
+- **Weights rare terms higher**: "kubernetes" is more distinctive than "create"
+- **Handles term frequency saturation**: Repeating a word doesn't linearly increase relevance
+- **Normalizes by document length**: Short and long descriptions scored fairly
+
+This means "backup database" finds tools mentioning "snapshot", "export", "persist" if those terms appear in similar contexts across the corpus.
+
+## Session Scope
+
+The registry is **session-scoped** (in-memory):
+
+- Fresh index each agent session
+- No persistence across sessions
+- Cheap to rebuild from source
+
+This is intentional - tool metadata changes, and re-registration ensures the index matches current reality.
+
+## Inspecting the Index
+
+Debug with `inspect_discovery_index`:
+
+```json
+{
+  "server_count": 2,
+  "tool_count": 85,
+  "term_count": 342,
+  "avg_doc_length": 12.4,
+  "servers": ["redisctl", "github"]
+}
+```
+
+List categories with `list_discovery_categories`:
+
+```json
+{
+  "enterprise": { "tool_count": 30, "servers": ["redisctl"] },
+  "cloud": { "tool_count": 25, "servers": ["redisctl"] },
+  "issues": { "tool_count": 8, "servers": ["github"] },
+  "pulls": { "tool_count": 6, "servers": ["github"] }
+}
+```

--- a/docs/book/src/mcp/overview.md
+++ b/docs/book/src/mcp/overview.md
@@ -22,11 +22,11 @@ When working with JSON data in Claude, jpx provides:
 
 ## Available Tools
 
-The MCP server exposes 17 tools organized by purpose:
+The MCP server exposes 25 tools organized by purpose:
 
-### Discovery Tools
+### Function Discovery Tools
 
-Tools for finding and exploring available functionality:
+Tools for finding and exploring available JMESPath functions:
 
 | Tool | Description |
 |------|-------------|
@@ -35,6 +35,21 @@ Tools for finding and exploring available functionality:
 | `functions` | List available functions (optionally filter by category) |
 | `describe` | Get detailed info for a specific function |
 | `categories` | List all function categories |
+
+### Multi-Server Tool Discovery
+
+Tools for semantic search across multiple MCP servers (see [Discovery](./discovery.md)):
+
+| Tool | Description |
+|------|-------------|
+| `register_discovery` | Register an MCP server's tools for indexing |
+| `query_tools` | BM25 semantic search across registered tools |
+| `similar_tools` | Find tools related to a specific tool |
+| `list_discovery_servers` | List registered servers |
+| `list_discovery_categories` | List tool categories across servers |
+| `inspect_discovery_index` | Debug index statistics |
+| `unregister_discovery` | Remove a server from the registry |
+| `get_discovery_schema` | Get the registration schema |
 
 ### Data Analysis Tools
 

--- a/docs/book/src/mcp/tools.md
+++ b/docs/book/src/mcp/tools.md
@@ -1,4 +1,290 @@
-# tools
+# Available Tools
 
-Coming soon.
+The jpx MCP server provides 25 tools organized into five categories.
 
+## Function Discovery
+
+Tools for exploring the 360+ JMESPath extension functions.
+
+### search
+
+Fuzzy search for functions by name, description, category, or signature.
+
+```json
+{
+  "query": "string manipulation",
+  "limit": 10
+}
+```
+
+### similar
+
+Find functions related to a specified function.
+
+```json
+{
+  "function": "upper",
+  "limit": 5
+}
+```
+
+Returns functions with similar purpose (e.g., `lower`, `capitalize`, `title_case`).
+
+### functions
+
+List available functions, optionally filtered by category.
+
+```json
+{
+  "category": "string"
+}
+```
+
+### describe
+
+Get detailed documentation for a specific function.
+
+```json
+{
+  "function": "pad_left"
+}
+```
+
+Returns signature, description, parameters, return type, and examples.
+
+### categories
+
+List all function categories with tool counts.
+
+```json
+{}
+```
+
+## Data Analysis
+
+Tools for understanding JSON structure before writing queries.
+
+### stats
+
+Analyze JSON structure and statistics.
+
+```json
+{
+  "json": {"users": [{"name": "Alice"}, {"name": "Bob"}]}
+}
+```
+
+Returns type, size, depth, and field analysis.
+
+### paths
+
+Extract all paths in a JSON document using dot notation.
+
+```json
+{
+  "json": {"user": {"profile": {"name": "Alice"}}}
+}
+```
+
+Returns: `["user", "user.profile", "user.profile.name"]`
+
+### keys
+
+Extract object keys, optionally recursive with dot notation.
+
+```json
+{
+  "json": {"a": {"b": 1}},
+  "recursive": true
+}
+```
+
+## Query Execution
+
+Tools for running JMESPath expressions.
+
+### evaluate
+
+Run a JMESPath expression against JSON input.
+
+```json
+{
+  "expression": "users[?age > `30`].name",
+  "json": {"users": [{"name": "Alice", "age": 35}, {"name": "Bob", "age": 25}]}
+}
+```
+
+Returns: `["Alice"]`
+
+### evaluate_file
+
+Query a JSON file directly from disk.
+
+```json
+{
+  "expression": "length(items)",
+  "path": "/path/to/data.json"
+}
+```
+
+### batch_evaluate
+
+Run multiple expressions against the same input.
+
+```json
+{
+  "expressions": ["length(@)", "keys(@)", "@.name"],
+  "json": {"name": "test", "value": 42}
+}
+```
+
+### validate
+
+Check expression syntax without executing.
+
+```json
+{
+  "expression": "users[?active].name"
+}
+```
+
+Returns validation status and any syntax errors.
+
+## JSON Utilities
+
+Tools for JSON manipulation following RFC standards.
+
+### format
+
+Pretty-print JSON with configurable indentation.
+
+```json
+{
+  "json": {"compact": true},
+  "indent": 2
+}
+```
+
+### diff
+
+Generate RFC 6902 JSON Patch between two documents.
+
+```json
+{
+  "source": {"a": 1},
+  "target": {"a": 2, "b": 3}
+}
+```
+
+Returns patch operations: `[{"op": "replace", "path": "/a", "value": 2}, {"op": "add", "path": "/b", "value": 3}]`
+
+### patch
+
+Apply RFC 6902 JSON Patch operations.
+
+```json
+{
+  "json": {"a": 1},
+  "operations": [{"op": "add", "path": "/b", "value": 2}]
+}
+```
+
+### merge
+
+Apply RFC 7396 JSON Merge Patch.
+
+```json
+{
+  "json": {"a": 1, "b": 2},
+  "patch": {"b": null, "c": 3}
+}
+```
+
+Returns: `{"a": 1, "c": 3}` (null removes keys)
+
+## Multi-Server Discovery
+
+Tools for semantic search across multiple MCP servers. See [Multi-Server Discovery](./discovery.md) for full documentation.
+
+### register_discovery
+
+Register an MCP server's tools for BM25 indexing.
+
+```json
+{
+  "spec": {
+    "server": {"name": "myserver", "version": "1.0.0"},
+    "tools": [
+      {"name": "tool_one", "description": "Does something useful", "category": "utils"}
+    ]
+  }
+}
+```
+
+### query_tools
+
+Semantic search across all registered tools.
+
+```json
+{
+  "query": "backup database",
+  "top_k": 5
+}
+```
+
+Returns ranked results with BM25 scores.
+
+### similar_tools
+
+Find tools related to a specific tool.
+
+```json
+{
+  "tool_id": "myserver:tool_one",
+  "top_k": 5
+}
+```
+
+### list_discovery_servers
+
+List all registered servers with tool counts.
+
+```json
+{}
+```
+
+### list_discovery_categories
+
+List tool categories across all registered servers.
+
+```json
+{}
+```
+
+### inspect_discovery_index
+
+Get index statistics for debugging.
+
+```json
+{}
+```
+
+Returns server count, tool count, term count, and average document length.
+
+### unregister_discovery
+
+Remove a server from the registry.
+
+```json
+{
+  "server": "myserver"
+}
+```
+
+### get_discovery_schema
+
+Get the JSON schema for registration.
+
+```json
+{}
+```


### PR DESCRIPTION
## Summary

Comprehensive documentation for the BM25-based multi-server tool discovery feature added in #291.

## Changes

### New Files

- **`docs/book/src/mcp/discovery.md`** - Full documentation of the discovery workflow:
  - Architecture explanation (agent-mediated registration)
  - Registration schema (minimal to full)
  - All discovery tools with examples
  - BM25 scoring explanation
  - Multi-server setup example
  - Recommended agent prompts

- **`AGENTS.md`** - Agent guidance for using jpx:
  - Quick start for JSON queries
  - Function discovery patterns
  - Multi-server registration workflow
  - **Copy-paste system prompt snippet** for auto-registration
  - Best practices

### Updated Files

- **`docs/book/src/mcp/overview.md`** - Added discovery tools section (8 new tools)
- **`docs/book/src/mcp/tools.md`** - Filled in documentation for all 25 MCP tools
- **`docs/book/src/SUMMARY.md`** - Added discovery page to navigation

## Agent Prompt Snippet

The key deliverable is this copy-paste prompt for agent configurations:

```markdown
## MCP Tool Discovery

At session start, if jpx and other MCP servers are connected:

1. For each non-jpx MCP server, register its tools with jpx:
   - Extract tool name, description, and input schema from each tool
   - Call `mcp__jpx__register_discovery` with the server name and tool list
   - Include category and tags if available for better search results

2. When searching for tools to accomplish a task:
   - Use `mcp__jpx__query_tools` for semantic search instead of scanning manually
   - Use `mcp__jpx__similar_tools` to find alternatives when exploring options

3. The registry is session-scoped - re-register if reconnecting.
```

## Closes

Closes #292