### PR TITLE
fix(ci): set PYO3_USE_ABI3_FORWARD_COMPATIBILITY for Python 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ on:
 env:
   # Use input tag for manual dispatch, otherwise use the pushed tag
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+  # PyO3 0.23 doesn't support Python 3.14 yet, use ABI3 forward compatibility
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
 
 jobs:
   # Run 'dist plan' to determine what tasks we need to do


### PR DESCRIPTION
macOS runners now have Python 3.14 by default, but PyO3 0.23 only supports up to 3.13. This env var enables forward compatibility using the stable ABI.

Fixes the release workflow failure.