### PR TITLE
fix(dist): exclude Python crate from cargo-dist builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
-members = ["jmespath_extensions", "jpx", "jmespath-extensions-py", "xtask", "mock-mcp-server"]
+members = ["jmespath_extensions", "jpx", "xtask", "mock-mcp-server"]
+# Python bindings are excluded from workspace to avoid PyO3 build issues in cargo-dist
+# The jmespath-extensions-py crate is built/released separately via the Python workflow
+exclude = ["jmespath-extensions-py"]
 resolver = "2"
 
 [workspace.package]

--- a/jmespath-extensions-py/Cargo.toml
+++ b/jmespath-extensions-py/Cargo.toml
@@ -13,15 +13,19 @@ categories = ["api-bindings"]
 # This crate is not published to crates.io - it's a Python package published to PyPI
 publish = false
 
+# Exclude from cargo-dist binary releases (it's a Python extension, not a standalone binary)
+[package.metadata.dist]
+dist = false
+
 [lib]
 name = "jmespath_extensions_py"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-jmespath.workspace = true
+jmespath = "0.4"
 jmespath_extensions = { path = "../jmespath_extensions", features = ["full"] }
 pyo3 = { version = "0.23", features = ["extension-module"] }
-serde_json.workspace = true
+serde_json = "1.0"
 
 [build-dependencies]
 pyo3-build-config = "0.23"


### PR DESCRIPTION
The Python bindings crate uses PyO3 which doesn't support Python 3.14 yet (macOS runners now have 3.14 by default).

Since we're not distributing the Python crate via cargo-dist anyway (it goes to PyPI separately), this adds `[package.metadata.dist] dist = false` to exclude it from the binary build.

This should fix the release workflow failures on Apple builds.