### PR TITLE
fix: remove jmespath-extensions-py from release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -21,8 +21,5 @@ publish = true
 git_release_enable = false
 git_tag_name = "jpx-v{{ version }}"
 
-# Python bindings - excluded from release-plz, uses separate python-release workflow
-[[package]]
-name = "jmespath-extensions-py"
-release = false
-publish = false
+# Note: jmespath-extensions-py is excluded from Cargo workspace and uses
+# a separate python-release workflow, so it's not listed here.


### PR DESCRIPTION
The package is excluded from the Cargo workspace and was causing release-plz to fail with 'not present in workspace' error.

It uses a separate python-release workflow instead, so it doesn't need to be listed in release-plz.toml.

Fixes the release-plz GitHub Action failure.