### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "jmespath_extensions"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.8.0" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.8.1" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.8.0...v0.8.1) - 2026-01-16
+
+### Added
+
+- *(discovery)* add search preprocessing for better BM25 indexing ([#333](https://github.com/joshrotenberg/jmespath-extensions/pull/333))
+- *(text)* add NLP toolkit functions ([#320](https://github.com/joshrotenberg/jmespath-extensions/pull/320))
+- *(cli)* improve help discoverability and set default binary ([#315](https://github.com/joshrotenberg/jmespath-extensions/pull/315))
+
+### Fixed
+
+- correct JMESPath literal syntax in function examples ([#334](https://github.com/joshrotenberg/jmespath-extensions/pull/334))
+
 ## [0.8.0](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.7.0...v0.8.0) - 2026-01-14
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.16...jpx-v0.1.17) - 2026-01-16
+
+### Added
+
+- *(discovery)* add search preprocessing for better BM25 indexing ([#333](https://github.com/joshrotenberg/jmespath-extensions/pull/333))
+- *(cli)* improve help discoverability and set default binary ([#315](https://github.com/joshrotenberg/jmespath-extensions/pull/315))
+- *(cli)* add two-tier help system (-h short, --help long) ([#313](https://github.com/joshrotenberg/jmespath-extensions/pull/313))
+
 ## [0.1.16](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.15...jpx-v0.1.16) - 2026-01-14
 
 ### Added

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.16"
+version = "0.1.17"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `jpx`: 0.1.16 -> 0.1.17 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.8.1](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.8.0...v0.8.1) - 2026-01-16

### Added

- *(discovery)* add search preprocessing for better BM25 indexing ([#333](https://github.com/joshrotenberg/jmespath-extensions/pull/333))
- *(text)* add NLP toolkit functions ([#320](https://github.com/joshrotenberg/jmespath-extensions/pull/320))
- *(cli)* improve help discoverability and set default binary ([#315](https://github.com/joshrotenberg/jmespath-extensions/pull/315))

### Fixed

- correct JMESPath literal syntax in function examples ([#334](https://github.com/joshrotenberg/jmespath-extensions/pull/334))
</blockquote>

## `jpx`

<blockquote>

## [0.1.17](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.16...jpx-v0.1.17) - 2026-01-16

### Added

- *(discovery)* add search preprocessing for better BM25 indexing ([#333](https://github.com/joshrotenberg/jmespath-extensions/pull/333))
- *(cli)* improve help discoverability and set default binary ([#315](https://github.com/joshrotenberg/jmespath-extensions/pull/315))
- *(cli)* add two-tier help system (-h short, --help long) ([#313](https://github.com/joshrotenberg/jmespath-extensions/pull/313))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).