### PR TITLE
feat: add from_entries as alias for from_items

### DIFF
--- a/jmespath_extensions/functions.toml
+++ b/jmespath_extensions/functions.toml
@@ -2640,6 +2640,18 @@ jep = "JEP-013"
 features = ["core", "jep"]
 
 [[functions]]
+name = "from_entries"
+category = "object"
+description = "Alias for from_items. Convert array of [key, value] pairs to object. Familiar to jq/lodash users."
+signature = "array -> object"
+examples = [
+    { code = "from_entries([['a', 1], ['b', 2]]) -> {a: 1, b: 2}", description = "Multiple pairs" },
+    { code = "items({a: 1, b: 2}) | from_entries(@) -> {a: 1, b: 2}", description = "Round-trip with items" },
+]
+alias_of = "from_items"
+features = ["core"]
+
+[[functions]]
 name = "get"
 category = "object"
 description = "Get value at dot-separated path with optional default"

--- a/jmespath_extensions/src/object.rs
+++ b/jmespath_extensions/src/object.rs
@@ -29,6 +29,7 @@ use crate::define_function;
 pub fn register(runtime: &mut Runtime) {
     runtime.register_function("items", Box::new(EntriesFn::new()));
     runtime.register_function("from_items", Box::new(FromEntriesFn::new()));
+    runtime.register_function("from_entries", Box::new(FromEntriesFn::new())); // alias for jq/lodash users
     runtime.register_function("with_entries", Box::new(WithEntriesFn::new()));
     runtime.register_function("pick", Box::new(PickFn::new()));
     runtime.register_function("omit", Box::new(OmitFn::new()));


### PR DESCRIPTION
Users coming from jq or lodash expect `from_entries` to pair with `to_entries`. This adds `from_entries` as an alias for `from_items` (the JEP-013 name).

## Changes
- Register `from_entries` as alias for `FromEntriesFn` in object.rs
- Add function metadata in functions.toml with `alias_of` field

## Usage
```bash
echo '[["a", 1], ["b", 2]]' | jpx 'from_entries(@)'
# {"a": 1, "b": 2}

# Round-trip with items (jq users will recognize this pattern)
echo '{"x": 1, "y": 2}' | jpx 'items(@) | from_entries(@)'
# {"x": 1, "y": 2}
```

Closes #329