### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "jmespath_extensions"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 
 # Internal crate
-jmespath_extensions = { path = "jmespath_extensions", version = "0.8.1" }
+jmespath_extensions = { path = "jmespath_extensions", version = "0.8.2" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/jmespath_extensions/CHANGELOG.md
+++ b/jmespath_extensions/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.8.1...v0.8.2) - 2026-01-17
+
+### Added
+
+- add from_entries as alias for from_items ([#340](https://github.com/joshrotenberg/jmespath-extensions/pull/340))
+
+### Fixed
+
+- *(registry)* enforce disable_function at runtime ([#358](https://github.com/joshrotenberg/jmespath-extensions/pull/358)) ([#360](https://github.com/joshrotenberg/jmespath-extensions/pull/360))
+
+### Other
+
+- documentation audit and improvements ([#355](https://github.com/joshrotenberg/jmespath-extensions/pull/355))
+- use heck crate for case conversion functions ([#348](https://github.com/joshrotenberg/jmespath-extensions/pull/348)) ([#349](https://github.com/joshrotenberg/jmespath-extensions/pull/349))
+
 ## [0.8.1](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.8.0...v0.8.1) - 2026-01-16
 
 ### Added

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/jpx/CHANGELOG.md
+++ b/jpx/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.17...jpx-v0.1.18) - 2026-01-17
+
+### Added
+
+- use default query for single-query .jpx files ([#362](https://github.com/joshrotenberg/jmespath-extensions/pull/362))
+- enable MCP feature by default ([#361](https://github.com/joshrotenberg/jmespath-extensions/pull/361))
+- *(mcp)* add runtime query storage tools ([#347](https://github.com/joshrotenberg/jmespath-extensions/pull/347))
+
+### Other
+
+- documentation audit and improvements ([#355](https://github.com/joshrotenberg/jmespath-extensions/pull/355))
+- improve error message for non-JSON input ([#343](https://github.com/joshrotenberg/jmespath-extensions/pull/343))
+
 ## [0.1.17](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.16...jpx-v0.1.17) - 2026-01-16
 
 ### Added

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.17"
+version = "0.1.18"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jmespath_extensions`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `jpx`: 0.1.17 -> 0.1.18 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jmespath_extensions`

<blockquote>

## [0.8.2](https://github.com/joshrotenberg/jmespath-extensions/compare/v0.8.1...v0.8.2) - 2026-01-17

### Added

- add from_entries as alias for from_items ([#340](https://github.com/joshrotenberg/jmespath-extensions/pull/340))

### Fixed

- *(registry)* enforce disable_function at runtime ([#358](https://github.com/joshrotenberg/jmespath-extensions/pull/358)) ([#360](https://github.com/joshrotenberg/jmespath-extensions/pull/360))

### Other

- documentation audit and improvements ([#355](https://github.com/joshrotenberg/jmespath-extensions/pull/355))
- use heck crate for case conversion functions ([#348](https://github.com/joshrotenberg/jmespath-extensions/pull/348)) ([#349](https://github.com/joshrotenberg/jmespath-extensions/pull/349))
</blockquote>

## `jpx`

<blockquote>

## [0.1.18](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.17...jpx-v0.1.18) - 2026-01-17

### Added

- use default query for single-query .jpx files ([#362](https://github.com/joshrotenberg/jmespath-extensions/pull/362))
- enable MCP feature by default ([#361](https://github.com/joshrotenberg/jmespath-extensions/pull/361))
- *(mcp)* add runtime query storage tools ([#347](https://github.com/joshrotenberg/jmespath-extensions/pull/347))

### Other

- documentation audit and improvements ([#355](https://github.com/joshrotenberg/jmespath-extensions/pull/355))
- improve error message for non-JSON input ([#343](https://github.com/joshrotenberg/jmespath-extensions/pull/343))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).