### PR TITLE
ux: improve error message for non-JSON input

### DIFF
--- a/jpx/src/main.rs
+++ b/jpx/src/main.rs
@@ -840,8 +840,7 @@ fn run() -> Result<()> {
             parse_slurp(&input)?
         } else {
             // Normal mode - parse single JSON value
-            Variable::from_json(&input)
-                .map_err(|e| anyhow::anyhow!("Failed to parse JSON input: {}", e))?
+            Variable::from_json(&input).map_err(|e| json_parse_error(&input, e))?
         }
     };
 
@@ -1003,6 +1002,59 @@ fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Create a helpful error message for JSON parse failures
+fn json_parse_error(input: &str, err: impl std::fmt::Display) -> anyhow::Error {
+    let trimmed = input.trim();
+    let preview = if trimmed.len() > 40 {
+        format!("{}...", &trimmed[..40])
+    } else {
+        trimmed.to_string()
+    };
+
+    // Detect common issues and provide specific suggestions
+    let suggestion = if trimmed.is_empty() {
+        "Input is empty. Use --null-input (-n) if you don't need input data.".to_string()
+    } else if !trimmed.starts_with('{')
+        && !trimmed.starts_with('[')
+        && !trimmed.starts_with('"')
+        && !trimmed.starts_with('-')
+        && !trimmed
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+        && trimmed != "true"
+        && trimmed != "false"
+        && trimmed != "null"
+    {
+        // Looks like plain text, not JSON
+        format!(
+            "Input appears to be plain text, not JSON.\n\n\
+             To pass a string value, wrap it in quotes:\n\
+               echo '\"{}\"' | jpx ...\n\n\
+             Or use --null-input (-n) if you don't need input data.",
+            preview.replace('\\', "\\\\").replace('"', "\\\"")
+        )
+    } else if trimmed.starts_with('\'') || trimmed.contains("': ") || trimmed.contains("':'") {
+        // Single quotes - common mistake
+        "JSON requires double quotes for strings, not single quotes.\n\
+         Replace ' with \" in your input."
+            .to_string()
+    } else {
+        // For other JSON parse errors, include the original error
+        format!(
+            "Parse error: {}\n\n\
+             Tip: Ensure your input is valid JSON. Common issues:\n\
+             - Strings must use double quotes (\"), not single quotes (')\n\
+             - Keys must be quoted: {{\"key\": \"value\"}}\n\
+             - No trailing commas in arrays or objects",
+            err
+        )
+    };
+
+    anyhow::anyhow!("Failed to parse JSON input\n\n{}", suggestion)
 }
 
 /// Parse multiple JSON values from input into an array


### PR DESCRIPTION
When JSON parsing fails, provide actionable suggestions based on the input:

## Examples

### Plain text input
```bash
$ echo 'hello world' | jpx 'length(@)'
jpx: Failed to parse JSON input

Input appears to be plain text, not JSON.

To pass a string value, wrap it in quotes:
  echo '"hello world"' | jpx ...

Or use --null-input (-n) if you don't need input data.
```

### Empty input
```bash
$ echo '' | jpx 'length(@)'
jpx: Failed to parse JSON input

Input is empty. Use --null-input (-n) if you don't need input data.
```

### Single quotes (common mistake)
```bash
$ echo "{'key': 'value'}" | jpx 'keys(@)'
jpx: Failed to parse JSON input

JSON requires double quotes for strings, not single quotes.
Replace ' with " in your input.
```

### Other parse errors (trailing comma, etc.)
```bash
$ echo '{"key": "value",}' | jpx 'keys(@)'
jpx: Failed to parse JSON input

Parse error: trailing comma at line 1 column 17

Tip: Ensure your input is valid JSON. Common issues:
- Strings must use double quotes ("), not single quotes (')
- Keys must be quoted: {"key": "value"}
- No trailing commas in arrays or objects
```

## Context

This is especially helpful for:
- Users coming from tools that auto-coerce strings
- MCP usage where input might be plain text from command output
- Piping output from other commands that isn't JSON

Closes #328