### PR TITLE
feat: add Docker container support for jpx CLI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,150 @@
+# Build and publish Docker images for jpx CLI
+#
+# Triggers after jpx releases and builds multi-arch images from the
+# pre-built binaries in the GitHub Release.
+
+name: Docker
+
+on:
+  # Trigger when a jpx release is published
+  release:
+    types: [published]
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build from (e.g., jpx-v0.1.17)"
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/jpx
+
+jobs:
+  # Build each architecture separately
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ubuntu-latest
+    # Only run for jpx releases (not library releases)
+    if: ${{ startsWith(github.event.release.tag_name || inputs.tag, 'jpx-v') }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            artifact: jpx-x86_64-unknown-linux-gnu.tar.xz
+            suffix: amd64
+          - platform: linux/arm64
+            artifact: jpx-aarch64-unknown-linux-gnu.tar.xz
+            suffix: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine tag and version
+        id: meta
+        run: |
+          TAG="${{ inputs.tag || github.event.release.tag_name }}"
+          VERSION="${TAG#jpx-v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download release binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          gh release download "$TAG" --pattern "${{ matrix.artifact }}" --dir /tmp
+          tar -xJf /tmp/${{ matrix.artifact }}
+          ls -la jpx
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-${{ matrix.suffix }}
+          labels: |
+            org.opencontainers.image.title=jpx
+            org.opencontainers.image.description=JMESPath CLI with extended functions
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+  # Create multi-arch manifest after all builds complete
+  manifest:
+    name: Create Multi-arch Manifest
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ startsWith(github.event.release.tag_name || inputs.tag, 'jpx-v') }}
+
+    permissions:
+      packages: write
+
+    steps:
+      - name: Determine version
+        id: meta
+        run: |
+          TAG="${{ inputs.tag || github.event.release.tag_name }}"
+          VERSION="${TAG#jpx-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifests
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+          # Create manifest for version tag
+          docker buildx imagetools create -t ${IMAGE}:${VERSION} \
+            ${IMAGE}:${VERSION}-amd64 \
+            ${IMAGE}:${VERSION}-arm64
+
+          # Create manifest for major.minor tag
+          docker buildx imagetools create -t ${IMAGE}:${MAJOR_MINOR} \
+            ${IMAGE}:${VERSION}-amd64 \
+            ${IMAGE}:${VERSION}-arm64
+
+          # Create manifest for major tag (only if major > 0)
+          if [ "$MAJOR" != "0" ]; then
+            docker buildx imagetools create -t ${IMAGE}:${MAJOR} \
+              ${IMAGE}:${VERSION}-amd64 \
+              ${IMAGE}:${VERSION}-arm64
+          fi
+
+          # Create manifest for latest tag
+          docker buildx imagetools create -t ${IMAGE}:latest \
+            ${IMAGE}:${VERSION}-amd64 \
+            ${IMAGE}:${VERSION}-arm64
+
+      - name: Verify multi-arch image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Dockerfile for jpx CLI
+# Used by docker.yml workflow to build images from pre-built release binaries
+#
+# Usage:
+#   echo '{"items": [1,2,3]}' | docker run -i ghcr.io/joshrotenberg/jpx 'length(items)'
+#
+# The workflow copies the appropriate binary for each platform before building.
+
+FROM alpine:3.21
+
+# Install ca-certificates for HTTPS support and create non-root user
+RUN apk add --no-cache ca-certificates \
+    && adduser -D -u 1000 jpx
+
+# Copy the pre-built binary (placed in context by workflow)
+COPY jpx /usr/local/bin/jpx
+RUN chmod +x /usr/local/bin/jpx
+
+# Use non-root user
+USER jpx
+WORKDIR /home/jpx
+
+# Set entrypoint
+ENTRYPOINT ["jpx"]
+
+# Default to showing help
+CMD ["--help"]


### PR DESCRIPTION
Adds Docker container support for jpx, making it easy to use in CI pipelines, scripts, and containerized environments.

## Usage

```bash
# Basic usage
echo '{"items": [1,2,3]}' | docker run -i ghcr.io/joshrotenberg/jpx 'length(items)'
# 3

# Process a file
docker run -i ghcr.io/joshrotenberg/jpx 'keys(@)' < data.json

# Use specific version
docker run -i ghcr.io/joshrotenberg/jpx:0.1.17 'sort(@)' < data.json
```

## Implementation

**Dockerfile:**
- Based on Alpine 3.21 for minimal size (~15MB base)
- Runs as non-root user for security
- Pre-built binaries from release (no compilation in container)

**GitHub Actions Workflow (`.github/workflows/docker.yml`):**
- Triggers automatically when a `jpx-v*` release is published
- Downloads pre-built Linux binaries from the GitHub Release
- Builds multi-arch images (linux/amd64 + linux/arm64)
- Pushes to GitHub Container Registry (ghcr.io)

**Tags created:**
- `:latest` - always points to newest release
- `:X.Y.Z` - full version (e.g., `:0.1.17`)
- `:X.Y` - major.minor (e.g., `:0.1`)
- `:X` - major only (e.g., `:1`) - only when major > 0

## Testing

The workflow can be manually triggered via `workflow_dispatch` with a specific tag for testing.

Closes #339