### PR TITLE
refactor: use heck crate for case conversion functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "criterion",
  "csv",
  "geoutils",
+ "heck 0.5.0",
  "hex",
  "hmac",
  "ipnetwork",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ whatlang = "0.18"
 rust-stemmers = "1.2"
 stop-words = "0.9"
 unicode-normalization = "0.1"
+heck = "0.5"
 
 # MCP server dependencies
 rmcp = { version = "0.12", features = ["server", "transport-io", "macros"] }

--- a/jmespath_extensions/Cargo.toml
+++ b/jmespath_extensions/Cargo.toml
@@ -45,6 +45,7 @@ whatlang = { workspace = true, optional = true }
 rust-stemmers = { workspace = true, optional = true }
 stop-words = { workspace = true, optional = true }
 unicode-normalization = { workspace = true, optional = true }
+heck.workspace = true
 
 [features]
 default = ["full"]

--- a/jmespath_extensions/src/object.rs
+++ b/jmespath_extensions/src/object.rs
@@ -19,6 +19,11 @@
 use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
 
+use heck::{
+    ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase, ToTrainCase,
+    ToUpperCamelCase,
+};
+
 use crate::common::{
     ArgumentType, Context, ErrorReason, Function, JmespathError, Rcvar, Runtime, Signature,
     Variable,
@@ -76,6 +81,10 @@ pub fn register(runtime: &mut Runtime) {
     runtime.register_function("snake_keys", Box::new(SnakeKeysFn::new()));
     runtime.register_function("camel_keys", Box::new(CamelKeysFn::new()));
     runtime.register_function("kebab_keys", Box::new(KebabKeysFn::new()));
+    runtime.register_function("pascal_keys", Box::new(PascalKeysFn::new()));
+    runtime.register_function("shouty_snake_keys", Box::new(ShoutySnakeKeysFn::new()));
+    runtime.register_function("shouty_kebab_keys", Box::new(ShoutyKebabKeysFn::new()));
+    runtime.register_function("train_keys", Box::new(TrainKeysFn::new()));
     // Structural diff functions
     runtime.register_function("structural_diff", Box::new(StructuralDiffFn::new()));
     runtime.register_function("has_same_shape", Box::new(HasSameShapeFn::new()));
@@ -2418,6 +2427,7 @@ fn paths_to_recursive(value: &Variable, key: &str, current_path: String, paths: 
 
 // =============================================================================
 // snake_keys(any) -> any (recursively convert all keys to snake_case)
+// Uses heck crate for proper case conversion
 // =============================================================================
 
 define_function!(SnakeKeysFn, vec![ArgumentType::Any], None);
@@ -2425,29 +2435,15 @@ define_function!(SnakeKeysFn, vec![ArgumentType::Any], None);
 impl Function for SnakeKeysFn {
     fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
         self.signature.validate(args, ctx)?;
-        Ok(Rc::new(transform_keys_recursive(&args[0], to_snake_case)))
+        Ok(Rc::new(transform_keys_recursive(&args[0], |s| {
+            s.to_snake_case()
+        })))
     }
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() {
-            if i > 0 {
-                result.push('_');
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else if c == '-' || c == ' ' {
-            result.push('_');
-        } else {
-            result.push(c);
-        }
-    }
-    result
 }
 
 // =============================================================================
 // camel_keys(any) -> any (recursively convert all keys to camelCase)
+// Uses heck crate for proper case conversion
 // =============================================================================
 
 define_function!(CamelKeysFn, vec![ArgumentType::Any], None);
@@ -2455,30 +2451,15 @@ define_function!(CamelKeysFn, vec![ArgumentType::Any], None);
 impl Function for CamelKeysFn {
     fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
         self.signature.validate(args, ctx)?;
-        Ok(Rc::new(transform_keys_recursive(&args[0], to_camel_case)))
+        Ok(Rc::new(transform_keys_recursive(&args[0], |s| {
+            s.to_lower_camel_case()
+        })))
     }
-}
-
-fn to_camel_case(s: &str) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = false;
-    for (i, c) in s.chars().enumerate() {
-        if c == '_' || c == '-' || c == ' ' {
-            capitalize_next = true;
-        } else if capitalize_next {
-            result.push(c.to_uppercase().next().unwrap());
-            capitalize_next = false;
-        } else if i == 0 {
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-    }
-    result
 }
 
 // =============================================================================
 // kebab_keys(any) -> any (recursively convert all keys to kebab-case)
+// Uses heck crate for proper case conversion
 // =============================================================================
 
 define_function!(KebabKeysFn, vec![ArgumentType::Any], None);
@@ -2486,25 +2467,74 @@ define_function!(KebabKeysFn, vec![ArgumentType::Any], None);
 impl Function for KebabKeysFn {
     fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
         self.signature.validate(args, ctx)?;
-        Ok(Rc::new(transform_keys_recursive(&args[0], to_kebab_case)))
+        Ok(Rc::new(transform_keys_recursive(&args[0], |s| {
+            s.to_kebab_case()
+        })))
     }
 }
 
-fn to_kebab_case(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() {
-            if i > 0 {
-                result.push('-');
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else if c == '_' || c == ' ' {
-            result.push('-');
-        } else {
-            result.push(c);
-        }
+// =============================================================================
+// pascal_keys(any) -> any (recursively convert all keys to PascalCase)
+// Uses heck crate - also known as UpperCamelCase
+// =============================================================================
+
+define_function!(PascalKeysFn, vec![ArgumentType::Any], None);
+
+impl Function for PascalKeysFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        Ok(Rc::new(transform_keys_recursive(&args[0], |s| {
+            s.to_upper_camel_case()
+        })))
     }
-    result
+}
+
+// =============================================================================
+// shouty_snake_keys(any) -> any (recursively convert all keys to SHOUTY_SNAKE_CASE)
+// Uses heck crate - useful for constants
+// =============================================================================
+
+define_function!(ShoutySnakeKeysFn, vec![ArgumentType::Any], None);
+
+impl Function for ShoutySnakeKeysFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        Ok(Rc::new(transform_keys_recursive(&args[0], |s| {
+            s.to_shouty_snake_case()
+        })))
+    }
+}
+
+// =============================================================================
+// shouty_kebab_keys(any) -> any (recursively convert all keys to SHOUTY-KEBAB-CASE)
+// Uses heck crate
+// =============================================================================
+
+define_function!(ShoutyKebabKeysFn, vec![ArgumentType::Any], None);
+
+impl Function for ShoutyKebabKeysFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        Ok(Rc::new(transform_keys_recursive(&args[0], |s| {
+            s.to_shouty_kebab_case()
+        })))
+    }
+}
+
+// =============================================================================
+// train_keys(any) -> any (recursively convert all keys to Train-Case)
+// Uses heck crate - like HTTP headers (Content-Type)
+// =============================================================================
+
+define_function!(TrainKeysFn, vec![ArgumentType::Any], None);
+
+impl Function for TrainKeysFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+        Ok(Rc::new(transform_keys_recursive(&args[0], |s| {
+            s.to_train_case()
+        })))
+    }
 }
 
 fn transform_keys_recursive<F>(value: &Variable, transform: F) -> Variable

--- a/jmespath_extensions/src/string.rs
+++ b/jmespath_extensions/src/string.rs
@@ -18,6 +18,11 @@
 
 use std::rc::Rc;
 
+use heck::{
+    ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase, ToTitleCase,
+    ToTrainCase, ToUpperCamelCase,
+};
+
 use crate::common::{
     ArgumentType, Context, ErrorReason, Function, JmespathError, Rcvar, Runtime, Variable,
 };
@@ -48,6 +53,10 @@ pub fn register(runtime: &mut Runtime) {
     runtime.register_function("camel_case", Box::new(CamelCaseFn::new()));
     runtime.register_function("snake_case", Box::new(SnakeCaseFn::new()));
     runtime.register_function("kebab_case", Box::new(KebabCaseFn::new()));
+    runtime.register_function("pascal_case", Box::new(PascalCaseFn::new()));
+    runtime.register_function("shouty_snake_case", Box::new(ShoutySnakeCaseFn::new()));
+    runtime.register_function("shouty_kebab_case", Box::new(ShoutyKebabCaseFn::new()));
+    runtime.register_function("train_case", Box::new(TrainCaseFn::new()));
     runtime.register_function("truncate", Box::new(TruncateFn::new()));
     runtime.register_function("wrap", Box::new(WrapFn::new()));
     runtime.register_function("format", Box::new(FormatFn::new()));
@@ -847,6 +856,7 @@ impl Function for LowerCaseFn {
 
 // =============================================================================
 // title_case(string) -> string (alias for title, snake_case style)
+// Uses heck crate for proper case conversion
 // =============================================================================
 
 define_function!(TitleCaseFn, vec![ArgumentType::String], None);
@@ -863,26 +873,13 @@ impl Function for TitleCaseFn {
             )
         })?;
 
-        let result = s
-            .split_whitespace()
-            .map(|word| {
-                let mut chars = word.chars();
-                match chars.next() {
-                    None => String::new(),
-                    Some(first) => {
-                        first.to_uppercase().to_string() + &chars.as_str().to_lowercase()
-                    }
-                }
-            })
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        Ok(Rc::new(Variable::String(result)))
+        Ok(Rc::new(Variable::String(s.to_title_case())))
     }
 }
 
 // =============================================================================
 // camel_case(string) -> string (helloWorld)
+// Uses heck crate for proper case conversion
 // =============================================================================
 
 define_function!(CamelCaseFn, vec![ArgumentType::String], None);
@@ -899,30 +896,13 @@ impl Function for CamelCaseFn {
             )
         })?;
 
-        let mut result = String::new();
-        let mut capitalize_next = false;
-        let mut first_word = true;
-
-        for c in s.chars() {
-            if c.is_alphanumeric() {
-                if capitalize_next && !first_word {
-                    result.push(c.to_ascii_uppercase());
-                    capitalize_next = false;
-                } else {
-                    result.push(c.to_ascii_lowercase());
-                }
-                first_word = false;
-            } else {
-                capitalize_next = true;
-            }
-        }
-
-        Ok(Rc::new(Variable::String(result)))
+        Ok(Rc::new(Variable::String(s.to_lower_camel_case())))
     }
 }
 
 // =============================================================================
 // snake_case(string) -> string (hello_world)
+// Uses heck crate for proper case conversion
 // =============================================================================
 
 define_function!(SnakeCaseFn, vec![ArgumentType::String], None);
@@ -939,36 +919,13 @@ impl Function for SnakeCaseFn {
             )
         })?;
 
-        let mut result = String::new();
-        let mut prev_was_lower = false;
-
-        for c in s.chars() {
-            if c.is_uppercase() {
-                if prev_was_lower && !result.is_empty() {
-                    result.push('_');
-                }
-                result.push(c.to_ascii_lowercase());
-                prev_was_lower = false;
-            } else if c.is_alphanumeric() {
-                result.push(c.to_ascii_lowercase());
-                prev_was_lower = c.is_lowercase();
-            } else if !result.is_empty() && !result.ends_with('_') {
-                result.push('_');
-                prev_was_lower = false;
-            }
-        }
-
-        // Trim trailing underscore
-        if result.ends_with('_') {
-            result.pop();
-        }
-
-        Ok(Rc::new(Variable::String(result)))
+        Ok(Rc::new(Variable::String(s.to_snake_case())))
     }
 }
 
 // =============================================================================
 // kebab_case(string) -> string (hello-world)
+// Uses heck crate for proper case conversion
 // =============================================================================
 
 define_function!(KebabCaseFn, vec![ArgumentType::String], None);
@@ -985,31 +942,99 @@ impl Function for KebabCaseFn {
             )
         })?;
 
-        let mut result = String::new();
-        let mut prev_was_lower = false;
+        Ok(Rc::new(Variable::String(s.to_kebab_case())))
+    }
+}
 
-        for c in s.chars() {
-            if c.is_uppercase() {
-                if prev_was_lower && !result.is_empty() {
-                    result.push('-');
-                }
-                result.push(c.to_ascii_lowercase());
-                prev_was_lower = false;
-            } else if c.is_alphanumeric() {
-                result.push(c.to_ascii_lowercase());
-                prev_was_lower = c.is_lowercase();
-            } else if !result.is_empty() && !result.ends_with('-') {
-                result.push('-');
-                prev_was_lower = false;
-            }
-        }
+// =============================================================================
+// pascal_case(string) -> string (HelloWorld)
+// Uses heck crate - also known as UpperCamelCase
+// =============================================================================
 
-        // Trim trailing hyphen
-        if result.ends_with('-') {
-            result.pop();
-        }
+define_function!(PascalCaseFn, vec![ArgumentType::String], None);
 
-        Ok(Rc::new(Variable::String(result)))
+impl Function for PascalCaseFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let s = args[0].as_string().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected string argument".to_owned()),
+            )
+        })?;
+
+        Ok(Rc::new(Variable::String(s.to_upper_camel_case())))
+    }
+}
+
+// =============================================================================
+// shouty_snake_case(string) -> string (HELLO_WORLD)
+// Uses heck crate - useful for constants
+// =============================================================================
+
+define_function!(ShoutySnakeCaseFn, vec![ArgumentType::String], None);
+
+impl Function for ShoutySnakeCaseFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let s = args[0].as_string().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected string argument".to_owned()),
+            )
+        })?;
+
+        Ok(Rc::new(Variable::String(s.to_shouty_snake_case())))
+    }
+}
+
+// =============================================================================
+// shouty_kebab_case(string) -> string (HELLO-WORLD)
+// Uses heck crate
+// =============================================================================
+
+define_function!(ShoutyKebabCaseFn, vec![ArgumentType::String], None);
+
+impl Function for ShoutyKebabCaseFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let s = args[0].as_string().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected string argument".to_owned()),
+            )
+        })?;
+
+        Ok(Rc::new(Variable::String(s.to_shouty_kebab_case())))
+    }
+}
+
+// =============================================================================
+// train_case(string) -> string (Hello-World)
+// Uses heck crate - like HTTP headers (Content-Type)
+// =============================================================================
+
+define_function!(TrainCaseFn, vec![ArgumentType::String], None);
+
+impl Function for TrainCaseFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let s = args[0].as_string().ok_or_else(|| {
+            JmespathError::new(
+                ctx.expression,
+                0,
+                ErrorReason::Parse("Expected string argument".to_owned()),
+            )
+        })?;
+
+        Ok(Rc::new(Variable::String(s.to_train_case())))
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces custom case conversion implementations with the [heck](https://crates.io/crates/heck) crate for improved accuracy and adds new case conversion styles.

## New String Functions

- `pascal_case` - "helloWorld" → "HelloWorld"
- `shouty_snake_case` - "helloWorld" → "HELLO_WORLD"
- `shouty_kebab_case` - "helloWorld" → "HELLO-WORLD"
- `train_case` - "helloWorld" → "Hello-World"

## New Object Key Functions

- `pascal_keys`
- `shouty_snake_keys`
- `shouty_kebab_keys`
- `train_keys`

## Breaking Change

Acronym handling is now improved. For example:
- `snake_case("XMLParser")` now returns `"xml_parser"` (previously returned `"xmlparser"`)

This is technically a breaking change but represents more correct behavior.

## Testing

All 201 tests pass.

Closes #348