### PR TITLE
feat: enable MCP feature by default

### DIFF
--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -37,12 +37,12 @@ cd jmespath-extensions/jpx
 cargo install --path .
 ```
 
-### With MCP Server Support
+### Without MCP Server Support
 
-To include the MCP server for AI assistant integration:
+MCP support is included by default. To build without it (smaller binary):
 
 ```bash
-cargo install --path . --features mcp
+cargo install --path . --no-default-features
 ```
 
 ## Verify Installation

--- a/docs/book/src/mcp/setup-claude.md
+++ b/docs/book/src/mcp/setup-claude.md
@@ -4,11 +4,11 @@ Configure jpx as an MCP server for Claude Desktop.
 
 ## Prerequisites
 
-1. Install jpx with MCP support:
+1. Install jpx (MCP support is included by default):
    ```bash
    brew install joshrotenberg/brew/jpx
    # or
-   cargo install jpx --features mcp
+   cargo install jpx
    ```
 
 2. Have Claude Desktop installed

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -56,5 +56,5 @@ tracing-subscriber = { workspace = true, optional = true }
 tempfile = "3"
 
 [features]
-default = []
+default = ["mcp"]
 mcp = ["rmcp", "schemars", "tokio", "tracing", "tracing-subscriber"]

--- a/jpx/README.md
+++ b/jpx/README.md
@@ -58,8 +58,8 @@ git clone https://github.com/joshrotenberg/jmespath-extensions
 cd jmespath-extensions/jpx
 cargo install --path .
 
-# With MCP server support
-cargo install --path . --features mcp
+# Without MCP server support (smaller binary)
+cargo install --path . --no-default-features
 ```
 
 ## MCP Server (AI Assistant Integration)
@@ -68,8 +68,16 @@ jpx can run as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io
 
 ### Building with MCP Support
 
+MCP support is included by default. Simply build:
+
 ```bash
-cargo build -p jpx --features mcp --release
+cargo build -p jpx --release
+```
+
+To build without MCP support (smaller binary):
+
+```bash
+cargo build -p jpx --no-default-features --release
 ```
 
 ### Running the Server


### PR DESCRIPTION
Enable the `mcp` feature by default to reduce friction for non-Rust developers using AI agents and MCP servers.

## Changes
- Add `mcp` to default features in `jpx/Cargo.toml`
- Update installation documentation to reflect the change
- Document `--no-default-features` for users wanting minimal builds

## Rationale
The ~3.3MB binary size increase (34%, from 9.7MB to 13MB) is acceptable for the convenience gain. Non-Rust developers using AI agents face unnecessary friction when forced to run `cargo install jpx --features mcp` versus simpler alternatives like `brew install jpx`.

Closes #352