### PR TITLE
fix: build ARM64 Docker image from source

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,19 +1,20 @@
 # Build and publish Docker images for jpx CLI
 #
-# Triggers after jpx releases and builds multi-arch images from the
-# pre-built binaries in the GitHub Release.
+# Triggers after the Release workflow completes successfully and builds
+# multi-arch images. AMD64 uses pre-built binaries, ARM64 builds from source.
 
 name: Docker
 
 on:
-  # Trigger when a jpx release is published
-  release:
-    types: [published]
+  # Trigger after Release workflow completes
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   # Allow manual trigger
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to build from (e.g., jpx-v0.1.17)"
+        description: "Release tag to build from (e.g., jpx-v0.1.18)"
         required: true
         type: string
 
@@ -22,26 +23,20 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/jpx
 
 jobs:
-  # Build each architecture separately
-  build:
-    name: Build ${{ matrix.platform }}
+  # Build AMD64 from pre-built binary
+  build-amd64:
+    name: Build linux/amd64
     runs-on: ubuntu-latest
-    # Only run for jpx releases (not library releases)
-    if: ${{ startsWith(github.event.release.tag_name || inputs.tag, 'jpx-v') }}
+    # Only run if Release workflow succeeded or manual trigger
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'jpx-v')) }}
 
     permissions:
       contents: read
       packages: write
 
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            artifact: jpx-x86_64-unknown-linux-gnu.tar.xz
-            suffix: amd64
-          - platform: linux/arm64
-            artifact: jpx-aarch64-unknown-linux-gnu.tar.xz
-            suffix: arm64
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
 
     steps:
       - name: Checkout
@@ -50,7 +45,11 @@ jobs:
       - name: Determine tag and version
         id: meta
         run: |
-          TAG="${{ inputs.tag || github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
           VERSION="${TAG#jpx-v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -60,9 +59,64 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.meta.outputs.tag }}"
-          gh release download "$TAG" --pattern "${{ matrix.artifact }}" --dir /tmp
-          tar -xJf /tmp/${{ matrix.artifact }}
+          gh release download "$TAG" --pattern "jpx-x86_64-unknown-linux-gnu.tar.xz" --dir /tmp
+          tar -xJf /tmp/jpx-x86_64-unknown-linux-gnu.tar.xz
           ls -la jpx
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-amd64
+          labels: |
+            org.opencontainers.image.title=jpx
+            org.opencontainers.image.description=JMESPath CLI with extended functions
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+  # Build ARM64 from source (no pre-built binary available)
+  build-arm64:
+    name: Build linux/arm64
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'jpx-v')) }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine tag and version
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          VERSION="${TAG#jpx-v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release tag
+        run: |
+          git fetch --tags
+          git checkout ${{ steps.meta.outputs.tag }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -81,10 +135,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
+          file: ./Dockerfile.build
+          platforms: linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-${{ matrix.suffix }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-arm64
           labels: |
             org.opencontainers.image.title=jpx
             org.opencontainers.image.description=JMESPath CLI with extended functions
@@ -95,20 +149,12 @@ jobs:
   manifest:
     name: Create Multi-arch Manifest
     runs-on: ubuntu-latest
-    needs: build
-    if: ${{ startsWith(github.event.release.tag_name || inputs.tag, 'jpx-v') }}
+    needs: [build-amd64, build-arm64]
 
     permissions:
       packages: write
 
     steps:
-      - name: Determine version
-        id: meta
-        run: |
-          TAG="${{ inputs.tag || github.event.release.tag_name }}"
-          VERSION="${TAG#jpx-v}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -118,7 +164,7 @@ jobs:
 
       - name: Create and push manifests
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
+          VERSION="${{ needs.build-amd64.outputs.version }}"
           MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
@@ -147,4 +193,4 @@ jobs:
 
       - name: Verify multi-arch image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-amd64.outputs.version }}

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,28 @@
+# Dockerfile for building jpx from source
+# Used for platforms without pre-built binaries (e.g., linux/arm64)
+
+# Build stage
+FROM rust:1.84-alpine AS builder
+
+RUN apk add --no-cache musl-dev
+
+WORKDIR /build
+COPY . .
+
+RUN cargo build --release -p jpx && \
+    strip target/release/jpx
+
+# Runtime stage
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates \
+    && adduser -D -u 1000 jpx
+
+COPY --from=builder /build/target/release/jpx /usr/local/bin/jpx
+RUN chmod +x /usr/local/bin/jpx
+
+USER jpx
+WORKDIR /home/jpx
+
+ENTRYPOINT ["jpx"]
+CMD ["--help"]


### PR DESCRIPTION
The cargo-dist release workflow doesn't build Linux ARM64 binaries, so the Docker workflow was failing when trying to download them.

## Changes
- Use `workflow_run` trigger instead of `release` event (more reliable)
- AMD64: continue using pre-built binary from release
- ARM64: build from source using new `Dockerfile.build`
- `Dockerfile.build`: multi-stage build with Rust Alpine

## Testing
After merge, manually trigger with:
```bash
gh workflow run docker.yml -f tag=jpx-v0.1.18
```