### PR TITLE
fix: use Rust 1.85 for edition 2024 support

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,7 +2,7 @@
 # Used for platforms without pre-built binaries (e.g., linux/arm64)
 
 # Build stage
-FROM rust:1.84-alpine AS builder
+FROM rust:1.85-alpine AS builder
 
 RUN apk add --no-cache musl-dev
 


### PR DESCRIPTION
Rust 1.84 doesn't support edition 2024. Bump to 1.85 for the ARM64 Docker build.