### PR TITLE
fix: use rust:alpine (latest) for Docker builds

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,7 +2,7 @@
 # Used for platforms without pre-built binaries (e.g., linux/arm64)
 
 # Build stage
-FROM rust:1.85-alpine AS builder
+FROM rust:alpine AS builder
 
 RUN apk add --no-cache musl-dev
 


### PR DESCRIPTION
darling@0.23.0 requires Rust 1.88+, so use the latest Alpine image instead of pinning to an older version.

Tested locally - builds and runs successfully.