### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/crates/jpx-server/CHANGELOG.md
+++ b/crates/jpx-server/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/joshrotenberg/jmespath-extensions/releases/tag/jpx-server-v0.1.0) - 2026-01-18
+
+### Fixed
+
+- add version to jpx-engine dependency in jpx-server ([#402](https://github.com/joshrotenberg/jmespath-extensions/pull/402))
+
+### Other
+
+- [**breaking**] extract jpx-engine/jpx-server and reorganize into crates/ directory ([#381](https://github.com/joshrotenberg/jmespath-extensions/pull/381))

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.18...jpx-v0.2.0) - 2026-01-18
+
+### Added
+
+- add Arrow support to jpx-engine and Parquet I/O to CLI ([#385](https://github.com/joshrotenberg/jmespath-extensions/pull/385))
+
+### Other
+
+- add jpx-server Docker image to MCP setup docs ([#396](https://github.com/joshrotenberg/jmespath-extensions/pull/396))
+- [**breaking**] extract jpx-engine/jpx-server and reorganize into crates/ directory ([#381](https://github.com/joshrotenberg/jmespath-extensions/pull/381))
+
 ## [0.1.18](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.17...jpx-v0.1.18) - 2026-01-17
 
 ### Added

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.1.18"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jpx`: 0.1.18 -> 0.2.0 (⚠ API breaking changes)
* `jpx-server`: 0.1.0

### ⚠ `jpx` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/feature_missing.ron

Failed in:
  feature tokio in the package's Cargo.toml
  feature mcp in the package's Cargo.toml
  feature tracing in the package's Cargo.toml
  feature schemars in the package's Cargo.toml
  feature tracing-subscriber in the package's Cargo.toml
  feature rmcp in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function jpx::mcp::query_store::query_store, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/query_store.rs:14
  function jpx::mcp::run, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/mod.rs:22

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/module_missing.ron

Failed in:
  mod jpx::mcp::query_store, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/query_store.rs:1
  mod jpx::mcp, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/mod.rs:1
  mod jpx::mcp::bm25, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/bm25.rs:1
  mod jpx::mcp::discovery, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  SCHEMA_VERSION in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:25

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct jpx::mcp::discovery::ReturnSpec, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:299
  struct jpx::mcp::discovery::CategoryInfo, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:327
  struct jpx::mcp::bm25::DocInfo, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/bm25.rs:110
  struct jpx::mcp::bm25::Bm25Index, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/bm25.rs:30
  struct jpx::mcp::bm25::TermScoreDetail, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/bm25.rs:165
  struct jpx::mcp::discovery::ServerInfo, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:202
  struct jpx::mcp::discovery::IndexStats, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:725
  struct jpx::mcp::discovery::ExampleSpec, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:311
  struct jpx::mcp::JpxMcp, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/tools.rs:526
  struct jpx::mcp::bm25::TermInfo, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/bm25.rs:125
  struct jpx::mcp::bm25::ScoreExplanation, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/bm25.rs:152
  struct jpx::mcp::discovery::ToolQueryResult, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:697
  struct jpx::mcp::discovery::ServerSummary, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:707
  struct jpx::mcp::discovery::ParamSpec, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:272
  struct jpx::mcp::discovery::ToolSpec, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:217
  struct jpx::mcp::query_store::QueryStore, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/query_store.rs:32
  struct jpx::mcp::bm25::IndexOptions, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/bm25.rs:57
  struct jpx::mcp::discovery::DiscoverySpec, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:184
  struct jpx::mcp::discovery::DiscoveryRegistry, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:339
  struct jpx::mcp::bm25::SearchResult, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/bm25.rs:135
  struct jpx::mcp::query_store::StoredQuery, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/query_store.rs:20
  struct jpx::mcp::discovery::RegistrationResult, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:689
  struct jpx::mcp::discovery::CategorySummary, previously in file /tmp/.tmpBX7Rbg/jpx/src/mcp/discovery.rs:716
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx`

<blockquote>

## [0.2.0](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.18...jpx-v0.2.0) - 2026-01-18

### Added

- add Arrow support to jpx-engine and Parquet I/O to CLI ([#385](https://github.com/joshrotenberg/jmespath-extensions/pull/385))

### Other

- add jpx-server Docker image to MCP setup docs ([#396](https://github.com/joshrotenberg/jmespath-extensions/pull/396))
- [**breaking**] extract jpx-engine/jpx-server and reorganize into crates/ directory ([#381](https://github.com/joshrotenberg/jmespath-extensions/pull/381))
</blockquote>

## `jpx-server`

<blockquote>

## [0.1.0](https://github.com/joshrotenberg/jmespath-extensions/releases/tag/jpx-server-v0.1.0) - 2026-01-18

### Fixed

- add version to jpx-engine dependency in jpx-server ([#402](https://github.com/joshrotenberg/jmespath-extensions/pull/402))

### Other

- [**breaking**] extract jpx-engine/jpx-server and reorganize into crates/ directory ([#381](https://github.com/joshrotenberg/jmespath-extensions/pull/381))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).