### PR TITLE
docs: add Docker quick start and MCP examples

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -23,10 +23,10 @@
 # MCP Server
 
 - [Overview](./mcp/overview.md)
-- [Setup with Claude](./mcp/setup-claude.md)
-- [Available Tools](./mcp/tools.md)
-- [Multi-Server Discovery](./mcp/discovery.md)
-- [Examples](./mcp/examples.md)
+  - [Setup with Claude](./mcp/setup-claude.md)
+  - [Available Tools](./mcp/tools.md)
+  - [Multi-Server Discovery](./mcp/discovery.md)
+  - [Examples](./mcp/examples.md)
 
 # Function Reference
 

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -1,5 +1,25 @@
 # Installation
 
+## Docker (Quickest)
+
+Try jpx instantly without installing anything:
+
+```bash
+# Pull the image
+docker pull ghcr.io/joshrotenberg/jpx
+
+# Run a query
+echo '{"name": "Alice", "age": 30}' | docker run -i ghcr.io/joshrotenberg/jpx 'name'
+# "Alice"
+
+# Fetch and transform data from an API
+curl -s 'https://hacker-news.firebaseio.com/v0/item/1.json' | \
+  docker run -i ghcr.io/joshrotenberg/jpx '{title: title, by: by, score: score}'
+# {"by": "pg", "score": 57, "title": "Y Combinator"}
+```
+
+Available for `linux/amd64` and `linux/arm64`.
+
 ## Homebrew (macOS/Linux)
 
 The easiest way to install jpx on macOS or Linux:

--- a/docs/book/src/mcp/setup-claude.md
+++ b/docs/book/src/mcp/setup-claude.md
@@ -15,6 +15,21 @@ Configure jpx as an MCP server for Claude Desktop.
 
 ## Configuration
 
+### Docker
+
+The simplest way to run jpx as an MCP server:
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/jpx", "mcp"]
+    }
+  }
+}
+```
+
 ### macOS
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:

--- a/jpx/README.md
+++ b/jpx/README.md
@@ -40,9 +40,39 @@ jq '.name | ascii_upcase'               jpx 'upper(name)'
 
 **[Full comparison →](https://joshrotenberg.github.io/jmespath-extensions/examples/jq-comparison.html)**
 
+## Quick Start (Docker)
+
+Try jpx instantly without installing anything:
+
+```bash
+# Fetch a Hacker News story and extract fields
+curl -s 'https://hacker-news.firebaseio.com/v0/item/1.json' | \
+  docker run -i ghcr.io/joshrotenberg/jpx '{title: title, by: by, score: score}'
+# {"by": "pg", "score": 57, "title": "Y Combinator"}
+
+# Basic query
+echo '{"name": "Alice", "scores": [85, 92, 78]}' | docker run -i ghcr.io/joshrotenberg/jpx 'name'
+# "Alice"
+
+# Calculate average
+echo '{"scores": [85, 92, 78]}' | docker run -i ghcr.io/joshrotenberg/jpx 'avg(scores)'
+# 85.0
+
+# String manipulation
+echo '{"name": "hello world"}' | docker run -i ghcr.io/joshrotenberg/jpx 'upper(name)'
+# "HELLO WORLD"
+
+# Filter and transform
+echo '[{"name":"alice","age":30},{"name":"bob","age":25}]' | docker run -i ghcr.io/joshrotenberg/jpx '[?age > `28`].name'
+# ["alice"]
+```
+
 ## Installation
 
 ```bash
+# Docker (no install needed)
+docker pull ghcr.io/joshrotenberg/jpx
+
 # Homebrew (macOS/Linux)
 brew tap joshrotenberg/brew
 brew install jpx
@@ -134,6 +164,19 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
     "jpx": {
       "command": "/path/to/jpx",
       "args": ["mcp"]
+    }
+  }
+}
+```
+
+Or use Docker (no installation required):
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/jpx", "mcp"]
     }
   }
 }


### PR DESCRIPTION
Add Docker-based examples to README and installation docs so users can try jpx instantly without installing anything.

Includes:
- Quick Start section with Docker examples at the top of README
- Docker as first installation option in docs
- Real-world curl + Hacker News API example
- Docker MCP server configuration for Claude Desktop
- Fix MCP sidebar indentation in book