### PR TITLE
fix(mcp): add proper type schema to register_discovery spec parameter

### DIFF
--- a/jpx/src/mcp/discovery.rs
+++ b/jpx/src/mcp/discovery.rs
@@ -17,6 +17,7 @@
 //! ```
 
 use super::bm25::{Bm25Index, IndexOptions};
+use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -180,7 +181,7 @@ fn expand_identifiers(text: &str) -> String {
 }
 
 /// Discovery spec - the schema MCP servers use to register their tools
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DiscoverySpec {
     /// JSON Schema reference (optional)
     #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
@@ -198,7 +199,7 @@ pub struct DiscoverySpec {
 }
 
 /// Server metadata
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ServerInfo {
     /// Server name (required)
     pub name: String,
@@ -213,7 +214,7 @@ pub struct ServerInfo {
 }
 
 /// Tool specification
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ToolSpec {
     /// Tool name (required)
     pub name: String,
@@ -268,7 +269,7 @@ pub struct ToolSpec {
 }
 
 /// Parameter specification
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ParamSpec {
     /// Parameter name
     pub name: String,
@@ -295,7 +296,7 @@ pub struct ParamSpec {
 }
 
 /// Return type specification
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ReturnSpec {
     /// Return type
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
@@ -307,7 +308,7 @@ pub struct ReturnSpec {
 }
 
 /// Example specification
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ExampleSpec {
     /// Example description
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -323,7 +324,7 @@ pub struct ExampleSpec {
 }
 
 /// Category information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CategoryInfo {
     /// Category description
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/jpx/src/mcp/tools.rs
+++ b/jpx/src/mcp/tools.rs
@@ -225,8 +225,8 @@ pub struct GetDiscoverySchemaParams {
 /// Parameters for the register_discovery tool
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct RegisterDiscoveryParams {
-    /// The discovery spec JSON
-    pub spec: Value,
+    /// The discovery spec containing server info and tool definitions
+    pub spec: DiscoverySpec,
     /// Replace existing registration if server already registered (default: false)
     #[serde(default)]
     pub replace: bool,
@@ -1195,17 +1195,12 @@ impl JpxMcp {
         &self,
         Parameters(params): Parameters<RegisterDiscoveryParams>,
     ) -> Result<CallToolResult, McpError> {
-        // Parse the spec
-        let spec: DiscoverySpec = serde_json::from_value(params.spec).map_err(|e| {
-            McpError::invalid_params(format!("Invalid discovery spec: {}", e), None)
-        })?;
-
         // Register with the global registry
         let result = {
             let mut registry = discovery_registry()
                 .write()
                 .map_err(|_| McpError::internal_error("Failed to acquire registry lock", None))?;
-            registry.register(spec, params.replace)
+            registry.register(params.spec, params.replace)
         };
 
         json_result(&result)


### PR DESCRIPTION
Fixes #370

## Summary
The `register_discovery` MCP tool's `spec` parameter was typed as `serde_json::Value`, which meant the JSON schema exposed to MCP clients showed no type information for this parameter. This made it difficult for LLMs to understand what structure the spec should have.

## Changes
- Added `schemars::JsonSchema` derive to `DiscoverySpec` and all its nested types in `discovery.rs`:
  - `ServerInfo`
  - `ToolSpec`
  - `ParamSpec`
  - `ReturnSpec`
  - `ExampleSpec`
  - `CategoryInfo`

- Changed `RegisterDiscoveryParams.spec` from `Value` to `DiscoverySpec`
- Removed the now-unnecessary JSON parsing step in the `register_discovery` tool implementation

## Result
MCP clients now see a fully typed schema for the `spec` parameter, including all required fields and their types. This helps LLMs correctly construct discovery specs when registering servers.