### PR TITLE
feat: improve search with synonym expansion and fuzzy suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "strsim",
  "tabled",
  "tempfile",
  "tokio",

--- a/jmespath_extensions/src/registry.rs
+++ b/jmespath_extensions/src/registry.rs
@@ -711,3 +711,421 @@ fn get_category_functions(category: Category) -> Vec<FunctionInfo> {
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/registry_data.rs"));
 }
+
+// =============================================================================
+// Synonym mapping for function discovery
+// =============================================================================
+
+/// Synonym entry mapping a search term to related function names/keywords
+pub struct SynonymEntry {
+    /// The search term (e.g., "aggregate")
+    pub term: &'static str,
+    /// Related function names or keywords that should match
+    pub targets: &'static [&'static str],
+}
+
+/// Get all synonym mappings for function discovery
+///
+/// Maps common search terms to function names/keywords that should match.
+/// Useful for improving search when users don't know exact function names.
+///
+/// # Example
+///
+/// ```
+/// use jmespath_extensions::registry::get_synonyms;
+///
+/// let synonyms = get_synonyms();
+/// // Find what "aggregate" maps to
+/// if let Some(entry) = synonyms.iter().find(|s| s.term == "aggregate") {
+///     assert!(entry.targets.contains(&"group_by"));
+/// }
+/// ```
+pub fn get_synonyms() -> &'static [SynonymEntry] {
+    static SYNONYMS: &[SynonymEntry] = &[
+        // Aggregation/grouping synonyms
+        SynonymEntry {
+            term: "aggregate",
+            targets: &[
+                "group_by",
+                "group_by_expr",
+                "sum",
+                "avg",
+                "count",
+                "reduce",
+                "fold",
+            ],
+        },
+        SynonymEntry {
+            term: "group",
+            targets: &["group_by", "group_by_expr", "chunk", "partition"],
+        },
+        SynonymEntry {
+            term: "collect",
+            targets: &["group_by", "group_by_expr", "flatten", "merge"],
+        },
+        SynonymEntry {
+            term: "bucket",
+            targets: &["group_by", "group_by_expr", "chunk"],
+        },
+        // Counting synonyms
+        SynonymEntry {
+            term: "count",
+            targets: &["length", "count_by", "count_if", "size"],
+        },
+        SynonymEntry {
+            term: "size",
+            targets: &["length", "count_by"],
+        },
+        SynonymEntry {
+            term: "len",
+            targets: &["length"],
+        },
+        // String manipulation synonyms
+        SynonymEntry {
+            term: "concat",
+            targets: &["join", "merge", "combine"],
+        },
+        SynonymEntry {
+            term: "combine",
+            targets: &["join", "merge", "concat"],
+        },
+        SynonymEntry {
+            term: "substring",
+            targets: &["slice", "substr", "mid"],
+        },
+        SynonymEntry {
+            term: "cut",
+            targets: &["slice", "split", "trim"],
+        },
+        SynonymEntry {
+            term: "strip",
+            targets: &["trim", "trim_left", "trim_right"],
+        },
+        SynonymEntry {
+            term: "lowercase",
+            targets: &["lower", "to_lower", "downcase"],
+        },
+        SynonymEntry {
+            term: "uppercase",
+            targets: &["upper", "to_upper", "upcase"],
+        },
+        SynonymEntry {
+            term: "replace",
+            targets: &["substitute", "gsub", "regex_replace"],
+        },
+        SynonymEntry {
+            term: "find",
+            targets: &["contains", "index_of", "search", "match"],
+        },
+        SynonymEntry {
+            term: "search",
+            targets: &["contains", "find", "index_of", "regex_match"],
+        },
+        // Array/list synonyms
+        SynonymEntry {
+            term: "filter",
+            targets: &["select", "where", "find_all", "keep"],
+        },
+        SynonymEntry {
+            term: "select",
+            targets: &["filter", "map", "pluck"],
+        },
+        SynonymEntry {
+            term: "transform",
+            targets: &["map", "transform_values", "map_values"],
+        },
+        SynonymEntry {
+            term: "first",
+            targets: &["head", "take", "front"],
+        },
+        SynonymEntry {
+            term: "last",
+            targets: &["tail", "end", "back"],
+        },
+        SynonymEntry {
+            term: "remove",
+            targets: &["reject", "delete", "drop", "exclude"],
+        },
+        SynonymEntry {
+            term: "unique",
+            targets: &["distinct", "uniq", "dedupe", "deduplicate"],
+        },
+        SynonymEntry {
+            term: "dedupe",
+            targets: &["unique", "distinct", "uniq"],
+        },
+        SynonymEntry {
+            term: "shuffle",
+            targets: &["random", "randomize", "permute"],
+        },
+        // Sorting synonyms
+        SynonymEntry {
+            term: "order",
+            targets: &["sort", "sort_by", "order_by", "arrange"],
+        },
+        SynonymEntry {
+            term: "arrange",
+            targets: &["sort", "sort_by", "order_by"],
+        },
+        SynonymEntry {
+            term: "rank",
+            targets: &["sort", "sort_by", "order_by"],
+        },
+        // Math synonyms
+        SynonymEntry {
+            term: "average",
+            targets: &["avg", "mean", "arithmetic_mean"],
+        },
+        SynonymEntry {
+            term: "mean",
+            targets: &["avg", "average"],
+        },
+        SynonymEntry {
+            term: "total",
+            targets: &["sum", "add", "accumulate"],
+        },
+        SynonymEntry {
+            term: "add",
+            targets: &["sum", "plus", "addition"],
+        },
+        SynonymEntry {
+            term: "subtract",
+            targets: &["minus", "difference"],
+        },
+        SynonymEntry {
+            term: "multiply",
+            targets: &["times", "product", "mul"],
+        },
+        SynonymEntry {
+            term: "divide",
+            targets: &["quotient", "div"],
+        },
+        SynonymEntry {
+            term: "remainder",
+            targets: &["mod", "modulo", "modulus"],
+        },
+        SynonymEntry {
+            term: "power",
+            targets: &["pow", "exponent", "exp"],
+        },
+        SynonymEntry {
+            term: "absolute",
+            targets: &["abs", "magnitude"],
+        },
+        SynonymEntry {
+            term: "round",
+            targets: &["round", "round_to", "nearest"],
+        },
+        SynonymEntry {
+            term: "random",
+            targets: &["rand", "random_int", "random_float"],
+        },
+        // Date/time synonyms
+        SynonymEntry {
+            term: "date",
+            targets: &["now", "today", "parse_date", "format_date", "datetime"],
+        },
+        SynonymEntry {
+            term: "time",
+            targets: &["now", "time_now", "parse_time", "datetime"],
+        },
+        SynonymEntry {
+            term: "timestamp",
+            targets: &["now", "epoch", "unix_time", "to_epoch"],
+        },
+        SynonymEntry {
+            term: "format",
+            targets: &["format_date", "strftime", "date_format"],
+        },
+        SynonymEntry {
+            term: "parse",
+            targets: &["parse_date", "parse_time", "strptime", "from_string"],
+        },
+        // Type conversion synonyms
+        SynonymEntry {
+            term: "convert",
+            targets: &["to_string", "to_number", "to_array", "type"],
+        },
+        SynonymEntry {
+            term: "cast",
+            targets: &["to_string", "to_number", "to_bool"],
+        },
+        SynonymEntry {
+            term: "stringify",
+            targets: &["to_string", "string", "str"],
+        },
+        SynonymEntry {
+            term: "numberify",
+            targets: &["to_number", "number", "int", "float"],
+        },
+        // Object/hash synonyms
+        SynonymEntry {
+            term: "object",
+            targets: &["from_items", "to_object", "merge", "object_from_items"],
+        },
+        SynonymEntry {
+            term: "dict",
+            targets: &["from_items", "to_object", "object"],
+        },
+        SynonymEntry {
+            term: "hash",
+            targets: &["md5", "sha256", "sha1", "crc32"],
+        },
+        SynonymEntry {
+            term: "encrypt",
+            targets: &["md5", "sha256", "sha1", "hmac"],
+        },
+        SynonymEntry {
+            term: "checksum",
+            targets: &["md5", "sha256", "crc32"],
+        },
+        // Encoding synonyms
+        SynonymEntry {
+            term: "encode",
+            targets: &["base64_encode", "url_encode", "hex_encode"],
+        },
+        SynonymEntry {
+            term: "decode",
+            targets: &["base64_decode", "url_decode", "hex_decode"],
+        },
+        SynonymEntry {
+            term: "escape",
+            targets: &["url_encode", "html_escape"],
+        },
+        SynonymEntry {
+            term: "unescape",
+            targets: &["url_decode", "html_unescape"],
+        },
+        // Validation synonyms
+        SynonymEntry {
+            term: "check",
+            targets: &[
+                "is_string",
+                "is_number",
+                "is_array",
+                "is_object",
+                "validate",
+            ],
+        },
+        SynonymEntry {
+            term: "validate",
+            targets: &["is_email", "is_url", "is_uuid", "is_valid"],
+        },
+        SynonymEntry {
+            term: "test",
+            targets: &["regex_match", "contains", "starts_with", "ends_with"],
+        },
+        // Null/empty handling synonyms
+        SynonymEntry {
+            term: "default",
+            targets: &["coalesce", "if_null", "or_else", "default_value"],
+        },
+        SynonymEntry {
+            term: "empty",
+            targets: &["is_empty", "blank", "null"],
+        },
+        SynonymEntry {
+            term: "null",
+            targets: &["is_null", "coalesce", "not_null"],
+        },
+        SynonymEntry {
+            term: "fallback",
+            targets: &["coalesce", "default", "or_else"],
+        },
+        // Comparison synonyms
+        SynonymEntry {
+            term: "equal",
+            targets: &["eq", "equals", "same"],
+        },
+        SynonymEntry {
+            term: "compare",
+            targets: &["eq", "lt", "gt", "lte", "gte", "cmp"],
+        },
+        SynonymEntry {
+            term: "between",
+            targets: &["range", "in_range", "clamp"],
+        },
+        // Misc synonyms
+        SynonymEntry {
+            term: "copy",
+            targets: &["clone", "dup", "duplicate"],
+        },
+        SynonymEntry {
+            term: "debug",
+            targets: &["debug", "inspect", "dump", "print"],
+        },
+        SynonymEntry {
+            term: "reverse",
+            targets: &["reverse", "flip", "invert"],
+        },
+        SynonymEntry {
+            term: "repeat",
+            targets: &["repeat", "replicate", "times"],
+        },
+        SynonymEntry {
+            term: "uuid",
+            targets: &["uuid", "uuid4", "guid", "generate_uuid"],
+        },
+        SynonymEntry {
+            term: "id",
+            targets: &["uuid", "nanoid", "ulid", "unique_id"],
+        },
+    ];
+    SYNONYMS
+}
+
+/// Look up synonyms for a search term
+///
+/// Returns the list of related function names/keywords if the term has synonyms,
+/// or None if not found.
+///
+/// # Example
+///
+/// ```
+/// use jmespath_extensions::registry::lookup_synonyms;
+///
+/// let targets = lookup_synonyms("aggregate");
+/// assert!(targets.is_some());
+/// assert!(targets.unwrap().contains(&"group_by"));
+/// ```
+pub fn lookup_synonyms(term: &str) -> Option<&'static [&'static str]> {
+    let term_lower = term.to_lowercase();
+    get_synonyms()
+        .iter()
+        .find(|s| s.term == term_lower)
+        .map(|s| s.targets)
+}
+
+/// Expand a search query using synonyms
+///
+/// Takes a search query (possibly multi-word) and returns all terms that should
+/// be searched, including the original terms and any synonym expansions.
+///
+/// # Example
+///
+/// ```
+/// use jmespath_extensions::registry::expand_search_terms;
+///
+/// let terms = expand_search_terms("group aggregate");
+/// assert!(terms.contains(&"group_by".to_string()));
+/// assert!(terms.contains(&"sum".to_string()));
+/// ```
+pub fn expand_search_terms(query: &str) -> Vec<String> {
+    let mut expanded = Vec::new();
+
+    for word in query.split_whitespace() {
+        let word_lower = word.to_lowercase();
+        expanded.push(word_lower.clone());
+
+        if let Some(targets) = lookup_synonyms(&word_lower) {
+            for target in targets {
+                let target_str = (*target).to_string();
+                if !expanded.contains(&target_str) {
+                    expanded.push(target_str);
+                }
+            }
+        }
+    }
+
+    expanded
+}

--- a/jpx/Cargo.toml
+++ b/jpx/Cargo.toml
@@ -51,10 +51,11 @@ schemars = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
+strsim = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"
 
 [features]
 default = ["mcp"]
-mcp = ["rmcp", "schemars", "tokio", "tracing", "tracing-subscriber"]
+mcp = ["rmcp", "schemars", "tokio", "tracing", "tracing-subscriber", "strsim"]

--- a/jpx/src/mcp/tools.rs
+++ b/jpx/src/mcp/tools.rs
@@ -2,7 +2,9 @@
 
 use jmespath::Runtime;
 use jmespath_extensions::register_all;
-use jmespath_extensions::registry::{Category, FunctionInfo, FunctionRegistry};
+use jmespath_extensions::registry::{
+    Category, FunctionInfo, FunctionRegistry, expand_search_terms, lookup_synonyms,
+};
 use rmcp::{
     ErrorData as McpError, ServerHandler, handler::server::router::tool::ToolRouter,
     handler::server::wrapper::Parameters, model::*, schemars, tool, tool_handler, tool_router,
@@ -10,6 +12,7 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::{OnceLock, RwLock};
+use strsim::jaro_winkler;
 
 use super::discovery::{DiscoveryRegistry, DiscoverySpec};
 use super::query_store::{self, StoredQuery};
@@ -377,6 +380,19 @@ pub struct SearchResult {
     pub match_type: String,
     /// Relevance score (higher = better match)
     pub score: i32,
+}
+
+/// Search response with results and suggestions
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SearchResponse {
+    /// Matching functions
+    pub results: Vec<SearchResult>,
+    /// "Did you mean" suggestions when no exact matches found
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub suggestions: Vec<String>,
+    /// Query terms that were expanded via synonyms
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expanded_terms: Vec<String>,
 }
 
 /// Similar functions result
@@ -962,7 +978,7 @@ impl JpxMcp {
 
     /// Search for functions by name, description, category, or signature
     #[tool(
-        description = "Search for JMESPath functions using fuzzy matching. Searches function names, descriptions, categories, signatures, and aliases. Returns ranked results with match type and relevance score. Essential for discovering functions when you're not sure of the exact name."
+        description = "Search for JMESPath functions using fuzzy matching. Searches function names, descriptions, categories, signatures, and aliases. Returns ranked results with match type and relevance score. Supports synonym expansion (e.g., 'aggregate' finds 'group_by') and provides 'did you mean' suggestions when no exact matches are found."
     )]
     async fn search(
         &self,
@@ -971,6 +987,22 @@ impl JpxMcp {
         let reg = registry();
         let query_lower = params.query.to_lowercase();
         let mut results: Vec<SearchResult> = Vec::new();
+        let mut expanded_terms: Vec<String> = Vec::new();
+
+        // Expand query using synonyms
+        let search_terms = expand_search_terms(&params.query);
+
+        // Track which terms were expanded from synonyms
+        for word in params.query.split_whitespace() {
+            let word_lower = word.to_lowercase();
+            if let Some(targets) = lookup_synonyms(&word_lower) {
+                for target in targets {
+                    if !expanded_terms.contains(&(*target).to_string()) {
+                        expanded_terms.push((*target).to_string());
+                    }
+                }
+            }
+        }
 
         for func in reg.functions() {
             let name_lower = func.name.to_lowercase();
@@ -978,7 +1010,7 @@ impl JpxMcp {
             let sig_lower = func.signature.to_lowercase();
             let cat_lower = func.category.name().to_lowercase();
 
-            // Scoring: higher = better match
+            // Check for matches with the original query first (highest priority)
             let (score, match_type) = if name_lower == query_lower {
                 (1000, "exact_name")
             } else if name_lower.starts_with(&query_lower) {
@@ -1000,7 +1032,29 @@ impl JpxMcp {
             } else if sig_lower.contains(&query_lower) {
                 (100, "signature_match")
             } else {
-                continue; // No match
+                // Check synonym-expanded terms
+                let mut synonym_match: Option<(i32, &str)> = None;
+                for term in &search_terms {
+                    if term == &query_lower {
+                        continue; // Already checked original query
+                    }
+                    if name_lower == *term {
+                        synonym_match = Some((450, "synonym_exact"));
+                        break;
+                    } else if name_lower.contains(term.as_str()) {
+                        synonym_match = Some((350, "synonym_contains"));
+                        break;
+                    } else if desc_lower.contains(term.as_str()) {
+                        synonym_match = Some((250, "synonym_description"));
+                        break;
+                    }
+                }
+
+                if let Some((s, t)) = synonym_match {
+                    (s, t)
+                } else {
+                    continue; // No match
+                }
             };
 
             results.push(SearchResult {
@@ -1016,13 +1070,53 @@ impl JpxMcp {
         // Limit results
         results.truncate(params.limit);
 
-        if results.is_empty() {
+        // If no results, find fuzzy suggestions using Jaro-Winkler
+        let suggestions = if results.is_empty() {
+            let mut fuzzy_matches: Vec<(String, f64)> = Vec::new();
+            let threshold = 0.7; // Minimum similarity score
+
+            for func in reg.functions() {
+                let similarity = jaro_winkler(&query_lower, &func.name.to_lowercase());
+                if similarity >= threshold {
+                    fuzzy_matches.push((func.name.to_string(), similarity));
+                }
+                // Also check aliases
+                for alias in func.aliases {
+                    let alias_sim = jaro_winkler(&query_lower, &alias.to_lowercase());
+                    if alias_sim >= threshold {
+                        fuzzy_matches.push((func.name.to_string(), alias_sim));
+                    }
+                }
+            }
+
+            // Sort by similarity descending and dedupe
+            fuzzy_matches
+                .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            let mut seen = std::collections::HashSet::new();
+            fuzzy_matches
+                .into_iter()
+                .filter(|(name, _)| seen.insert(name.clone()))
+                .take(5)
+                .map(|(name, _)| name)
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Build response
+        let response = SearchResponse {
+            results,
+            suggestions,
+            expanded_terms,
+        };
+
+        if response.results.is_empty() && response.suggestions.is_empty() {
             Ok(error_result(format!(
                 "No functions found matching '{}'. Try broader search terms like 'string', 'array', 'date', 'hash', etc.",
                 params.query
             )))
         } else {
-            json_result(&results)
+            json_result(&response)
         }
     }
 
@@ -3238,11 +3332,11 @@ mod tests {
 
         if let Some(content) = result.content.first() {
             if let RawContent::Text(text_content) = &content.raw {
-                let results: Vec<SearchResult> = serde_json::from_str(&text_content.text).unwrap();
-                assert!(!results.is_empty());
+                let response: SearchResponse = serde_json::from_str(&text_content.text).unwrap();
+                assert!(!response.results.is_empty());
                 // First result should be exact match
-                assert_eq!(results[0].function.name, "upper");
-                assert_eq!(results[0].match_type, "exact_name");
+                assert_eq!(response.results[0].function.name, "upper");
+                assert_eq!(response.results[0].match_type, "exact_name");
             } else {
                 panic!("Expected text content");
             }
@@ -3263,12 +3357,17 @@ mod tests {
 
         if let Some(content) = result.content.first() {
             if let RawContent::Text(text_content) = &content.raw {
-                let results: Vec<SearchResult> = serde_json::from_str(&text_content.text).unwrap();
-                assert!(!results.is_empty());
-                // Should find hash-related functions
-                assert!(results.iter().any(|r| r.function.name.contains("md5")
-                    || r.function.name.contains("sha")
-                    || r.function.category == "Hash"));
+                let response: SearchResponse = serde_json::from_str(&text_content.text).unwrap();
+                assert!(!response.results.is_empty());
+                // Should find hash-related functions (via synonym expansion)
+                assert!(
+                    response
+                        .results
+                        .iter()
+                        .any(|r| r.function.name.contains("md5")
+                            || r.function.name.contains("sha")
+                            || r.function.category == "Hash")
+                );
             } else {
                 panic!("Expected text content");
             }
@@ -3287,6 +3386,66 @@ mod tests {
         let result = mcp.search(Parameters(params)).await.unwrap();
         // Should return error result (not Err)
         assert_eq!(result.is_error, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_search_synonym_expansion() {
+        let mcp = JpxMcp::new(false);
+        let params = SearchParams {
+            query: "aggregate".to_string(),
+            limit: 20,
+        };
+        let result = mcp.search(Parameters(params)).await.unwrap();
+        assert_eq!(result.is_error, Some(false));
+
+        if let Some(content) = result.content.first() {
+            if let RawContent::Text(text_content) = &content.raw {
+                let response: SearchResponse = serde_json::from_str(&text_content.text).unwrap();
+                // Should find group_by via synonym expansion
+                assert!(
+                    response
+                        .results
+                        .iter()
+                        .any(|r| r.function.name == "group_by"),
+                    "Expected to find group_by via synonym expansion"
+                );
+                // expanded_terms should contain the synonym targets
+                assert!(
+                    response.expanded_terms.contains(&"group_by".to_string()),
+                    "Expected expanded_terms to contain group_by"
+                );
+            } else {
+                panic!("Expected text content");
+            }
+        } else {
+            panic!("Expected content");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_search_fuzzy_suggestions() {
+        let mcp = JpxMcp::new(false);
+        let params = SearchParams {
+            query: "uper".to_string(), // typo for "upper"
+            limit: 10,
+        };
+        let result = mcp.search(Parameters(params)).await.unwrap();
+        assert_eq!(result.is_error, Some(false));
+
+        if let Some(content) = result.content.first() {
+            if let RawContent::Text(text_content) = &content.raw {
+                let response: SearchResponse = serde_json::from_str(&text_content.text).unwrap();
+                // Should have suggestions including "upper"
+                assert!(
+                    response.suggestions.contains(&"upper".to_string()),
+                    "Expected suggestions to contain 'upper' for typo 'uper'"
+                );
+            } else {
+                panic!("Expected text content");
+            }
+        } else {
+            panic!("Expected content");
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
Closes #371

## Changes

This PR improves the `jpx:search` MCP tool with:

### Synonym Expansion
- Added a synonym mapping system to the `jmespath_extensions` registry module
- Maps common search terms to related function names (e.g., "aggregate" -> "group_by", "group_by_expr", "sum", "avg", etc.)
- Exported as public API: `get_synonyms()`, `lookup_synonyms()`, `expand_search_terms()`
- Placed in the registry module so it's reusable across CLI and MCP tools

### Fuzzy "Did You Mean" Suggestions  
- When no matches are found, uses Jaro-Winkler similarity to suggest similar function names
- Threshold of 0.7 for suggestions, returns top 5 most similar
- Added `strsim` dependency to jpx crate

### Updated Response Format
- New `SearchResponse` struct with:
  - `results`: matching functions (as before)
  - `suggestions`: fuzzy suggestions when no results found
  - `expanded_terms`: shows which synonym targets were used

### Example
Searching for "group aggregate" now returns `group_by`, `group_by_expr`, `sum`, `avg`, etc. instead of "No functions found".

## Testing
- Added tests for synonym expansion
- Added tests for fuzzy suggestions
- All existing tests updated and passing