### PR TITLE
feat: add Clojure-inspired Phase 2 functions (mapcat, reductions, none)

### DIFF
--- a/crates/jmespath-extensions/functions.toml
+++ b/crates/jmespath-extensions/functions.toml
@@ -1271,7 +1271,21 @@ examples = [
     { code = "flat_map_expr(users, &tags) -> all tags flattened", description = "Flatten object arrays" },
     { code = "flat_map_expr([], &@) -> []", description = "Empty array" },
 ]
+aliases = ["mapcat"]
 features = ["core"]
+
+[[functions]]
+name = "mapcat"
+category = "expression"
+description = "Apply expression to each element and concatenate all results (Clojure-style alias for flat_map_expr)"
+signature = "string, array -> array"
+examples = [
+    { code = "mapcat('tags', [{tags: ['a', 'b']}, {tags: ['c']}]) -> ['a', 'b', 'c']", description = "Flatten tags from objects" },
+    { code = "mapcat('@', [[1, 2], [3, 4]]) -> [1, 2, 3, 4]", description = "Flatten nested arrays" },
+    { code = "mapcat('children', tree_nodes) -> all children flattened", description = "Flatten tree children" },
+    { code = "mapcat('tags', []) -> []", description = "Empty array" },
+]
+features = ["core", "fp"]
 
 [[functions]]
 name = "group_by_expr"
@@ -1427,6 +1441,33 @@ examples = [
     { code = "scan_expr('multiply(accumulator, current)', [2, 3, 4], `1`) -> [2, 6, 24]", description = "Running product" },
     { code = "scan_expr('max(accumulator, current)', [3, 1, 4], `0`) -> [3, 3, 4]", description = "Running max" },
     { code = "scan_expr('add(accumulator, current)', [], `0`) -> []", description = "Empty array" },
+]
+aliases = ["reductions"]
+features = ["core", "fp"]
+
+[[functions]]
+name = "reductions"
+category = "expression"
+description = "Return array of intermediate values from reduction (Clojure-style alias for scan_expr)"
+signature = "string, array, any -> array"
+examples = [
+    { code = "reductions('sum([accumulator, current])', [1, 2, 3, 4], `0`) -> [1, 3, 6, 10]", description = "Running sum" },
+    { code = "reductions('max([accumulator, current])', [3, 1, 4, 1, 5], `0`) -> [3, 3, 4, 4, 5]", description = "Running max" },
+    { code = "reductions('sum([accumulator, current])', [], `0`) -> []", description = "Empty array" },
+    { code = "reductions('merge(accumulator, current)', objects, `{}`) -> accumulated merges", description = "Cumulative merge" },
+]
+features = ["core", "fp"]
+
+[[functions]]
+name = "none"
+category = "expression"
+description = "Return true if no elements satisfy the expression (opposite of any_expr/some)"
+signature = "string, array -> boolean"
+examples = [
+    { code = "none('@ > `5`', [1, 2, 3]) -> true", description = "No elements > 5" },
+    { code = "none('@ > `5`', [1, 2, 10]) -> false", description = "10 is > 5" },
+    { code = "none('active', [{active: false}, {active: false}]) -> true", description = "No active elements" },
+    { code = "none('@ > `0`', []) -> true", description = "Empty array is vacuously true" },
 ]
 features = ["core", "fp"]
 

--- a/crates/jmespath-extensions/src/expression.rs
+++ b/crates/jmespath-extensions/src/expression.rs
@@ -41,6 +41,8 @@ pub fn register(runtime: &mut Runtime) {
     runtime.register_function("max_by_expr", Box::new(MaxByExprFn::new()));
     runtime.register_function("unique_by_expr", Box::new(UniqueByExprFn::new()));
     runtime.register_function("flat_map_expr", Box::new(FlatMapExprFn::new()));
+    // Clojure-style alias for flat_map_expr
+    runtime.register_function("mapcat", Box::new(FlatMapExprFn::new()));
 
     // Lodash-style aliases
     runtime.register_function("some", Box::new(AnyExprFn::new()));
@@ -53,6 +55,10 @@ pub fn register(runtime: &mut Runtime) {
     runtime.register_function("scan_expr", Box::new(ScanExprFn::new()));
     // Alias for reduce_expr (lodash-style)
     runtime.register_function("fold", Box::new(ReduceExprFn::new()));
+    // Clojure-style alias for scan_expr
+    runtime.register_function("reductions", Box::new(ScanExprFn::new()));
+    // none - opposite of any_expr/some
+    runtime.register_function("none", Box::new(NoneFn::new()));
     runtime.register_function("count_by", Box::new(CountByFn::new()));
 
     // Partial application functions
@@ -154,6 +160,12 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     register_if_enabled!(runtime, enabled, "scan_expr", Box::new(ScanExprFn::new()));
     // Alias for reduce_expr (lodash-style)
     register_if_enabled!(runtime, enabled, "fold", Box::new(ReduceExprFn::new()));
+    // Clojure-style alias for flat_map_expr
+    register_if_enabled!(runtime, enabled, "mapcat", Box::new(FlatMapExprFn::new()));
+    // Clojure-style alias for scan_expr
+    register_if_enabled!(runtime, enabled, "reductions", Box::new(ScanExprFn::new()));
+    // none - opposite of any_expr/some
+    register_if_enabled!(runtime, enabled, "none", Box::new(NoneFn::new()));
     register_if_enabled!(runtime, enabled, "count_by", Box::new(CountByFn::new()));
 
     // Partial application functions
@@ -364,6 +376,80 @@ impl Function for AnyExprFn {
         }
 
         Ok(Rc::new(Variable::Bool(false)))
+    }
+}
+
+// =============================================================================
+// none(expr, array) -> bool (opposite of any_expr/some)
+// =============================================================================
+
+/// Check if no elements in the array match the expression.
+///
+/// This is the logical opposite of `any_expr`/`some`. Returns `true` if
+/// the predicate returns falsy for every element.
+///
+/// # Arguments
+/// * `expr` - A JMESPath expression string that returns a truthy/falsy value
+/// * `array` - The array to check
+///
+/// # Returns
+/// `true` if no element produces a truthy result, `false` if any element does.
+/// Returns `true` for empty arrays (vacuously true).
+///
+/// # Example
+/// ```text
+/// none('@ > `5`', [1, 2, 3]) -> true
+/// none('@ > `5`', [1, 2, 10]) -> false
+/// none('active', [{"active": false}, {"active": false}]) -> true
+/// ```
+pub struct NoneFn {
+    signature: Signature,
+}
+
+impl Default for NoneFn {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NoneFn {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(vec![ArgumentType::String, ArgumentType::Array], None),
+        }
+    }
+}
+
+impl Function for NoneFn {
+    fn evaluate(&self, args: &[Rcvar], ctx: &mut Context<'_>) -> Result<Rcvar, JmespathError> {
+        self.signature.validate(args, ctx)?;
+
+        let expr_str = args[0].as_string().unwrap();
+        let arr = args[1].as_array().unwrap();
+
+        // Empty array returns true (vacuously, no elements satisfy the predicate)
+        if arr.is_empty() {
+            return Ok(Rc::new(Variable::Bool(true)));
+        }
+
+        let compiled = ctx.runtime.compile(expr_str).map_err(|e| {
+            JmespathError::new(
+                ctx.expression,
+                ctx.offset,
+                ErrorReason::Parse(format!("Invalid expression in none: {}", e)),
+            )
+        })?;
+
+        // Return false as soon as any element satisfies the predicate
+        for item in arr {
+            let result = compiled.search(item.clone())?;
+            if is_truthy(&result) {
+                return Ok(Rc::new(Variable::Bool(false)));
+            }
+        }
+
+        // No element satisfied the predicate
+        Ok(Rc::new(Variable::Bool(true)))
     }
 }
 
@@ -3076,6 +3162,73 @@ mod tests {
         let expr = runtime.compile("every('@ > `0`', @)").unwrap();
         let result = expr.search(&data).unwrap();
         assert!(result.as_boolean().unwrap());
+    }
+
+    #[test]
+    fn test_none_true() {
+        let runtime = setup();
+        let data = Variable::from_json(r#"[1, 2, 3]"#).unwrap();
+        let expr = runtime.compile("none('@ > `5`', @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_boolean().unwrap()); // No element > 5
+    }
+
+    #[test]
+    fn test_none_false() {
+        let runtime = setup();
+        let data = Variable::from_json(r#"[1, 2, 10]"#).unwrap();
+        let expr = runtime.compile("none('@ > `5`', @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_boolean().unwrap()); // 10 > 5
+    }
+
+    #[test]
+    fn test_none_empty() {
+        let runtime = setup();
+        let data = Variable::from_json(r#"[]"#).unwrap();
+        let expr = runtime.compile("none('@ > `0`', @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_boolean().unwrap()); // Vacuously true
+    }
+
+    #[test]
+    fn test_none_objects() {
+        let runtime = setup();
+        let data = Variable::from_json(r#"[{"active": false}, {"active": false}]"#).unwrap();
+        let expr = runtime.compile("none('active', @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_boolean().unwrap()); // No active elements
+    }
+
+    #[test]
+    fn test_mapcat_alias() {
+        let runtime = setup();
+        let data =
+            Variable::from_json(r#"[{"tags": ["a", "b"]}, {"tags": ["c"]}, {"tags": ["d", "e"]}]"#)
+                .unwrap();
+        let expr = runtime.compile("mapcat('tags', @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr[0].as_string().unwrap(), "a");
+        assert_eq!(arr[4].as_string().unwrap(), "e");
+    }
+
+    #[test]
+    fn test_reductions_alias() {
+        let runtime = setup();
+        let data = Variable::from_json(r#"[1, 2, 3, 4]"#).unwrap();
+        let expr = runtime
+            .compile("reductions('sum([accumulator, current])', @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Running sum: [1, 3, 6, 10]
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0].as_number().unwrap(), 1.0);
+        assert_eq!(arr[1].as_number().unwrap(), 3.0);
+        assert_eq!(arr[2].as_number().unwrap(), 6.0);
+        assert_eq!(arr[3].as_number().unwrap(), 10.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds Phase 2 Clojure-inspired functions from #386.

## Changes

### New Functions/Aliases

- **`mapcat`**: Clojure-style alias for `flat_map_expr` - applies expression to each element and concatenates results
- **`reductions`**: Clojure-style alias for `scan_expr` - returns array of intermediate accumulator values (like Clojure's reductions)
- **`none`**: Returns true if no elements satisfy the predicate (opposite of `any_expr`/`some`)

### Testing

- Added comprehensive tests for all new functions:
  - `test_none_true`, `test_none_false`, `test_none_empty`, `test_none_objects`
  - `test_mapcat_alias`
  - `test_reductions_alias`

### Documentation

- Updated `functions.toml` with entries for all new functions including examples

## Relationship to Other Work

Part of the Clojure-inspired functions tracking issue #386.

## Checklist

- [x] Tests pass (`cargo test --lib --all-features`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Format check passes (`cargo fmt --all -- --check`)
- [x] functions.toml updated