### PR TITLE
feat: expand benchmark coverage for functions

### DIFF
--- a/crates/jmespath-extensions/benches/functions.rs
+++ b/crates/jmespath-extensions/benches/functions.rs
@@ -34,6 +34,53 @@ fn bench_string_functions(c: &mut Criterion) {
     let expr = runtime.compile("camel_case(@)").unwrap();
     group.bench_function("camel_case", |b| b.iter(|| expr.search(black_box(&data))));
 
+    // Trim operations
+    let padded = Variable::String("   hello world   ".to_string());
+    let expr = runtime.compile("trim(@)").unwrap();
+    group.bench_function("trim", |b| b.iter(|| expr.search(black_box(&padded))));
+
+    // Pad operations
+    let short = Variable::String("hello".to_string());
+    let expr = runtime.compile("pad_left(@, `20`, ' ')").unwrap();
+    group.bench_function("pad_left", |b| b.iter(|| expr.search(black_box(&short))));
+
+    let expr = runtime.compile("pad_right(@, `20`, ' ')").unwrap();
+    group.bench_function("pad_right", |b| b.iter(|| expr.search(black_box(&short))));
+
+    group.finish();
+}
+
+#[cfg(feature = "regex")]
+fn bench_regex_functions(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("regex");
+
+    let email = Variable::String("user@example.com".to_string());
+
+    let expr = runtime
+        .compile(r#"regex_match(@, `"^[a-z]+@[a-z]+\\.[a-z]+$"`)"#)
+        .unwrap();
+    group.bench_function("regex_match/simple", |b| {
+        b.iter(|| expr.search(black_box(&email)))
+    });
+
+    let text = Variable::String("The quick brown fox jumps over the lazy dog".to_string());
+    let expr = runtime
+        .compile(r#"regex_replace(@, `"[aeiou]"`, `"*"`)"#)
+        .unwrap();
+    group.bench_function("regex_replace", |b| {
+        b.iter(|| expr.search(black_box(&text)))
+    });
+
+    // Larger text
+    let large_text = Variable::String("Hello world! ".repeat(100));
+    let expr = runtime.compile(r#"regex_match(@, `"world"`)"#).unwrap();
+    group.bench_with_input(
+        BenchmarkId::new("regex_match", "large"),
+        &large_text,
+        |b, data| b.iter(|| expr.search(black_box(data))),
+    );
+
     group.finish();
 }
 
@@ -132,6 +179,267 @@ fn bench_array_functions(c: &mut Criterion) {
         &objects,
         |b, data| b.iter(|| expr.search(black_box(data))),
     );
+
+    // flatten_deep - nested arrays
+    let nested: Vec<serde_json::Value> = (0..20)
+        .map(|i| serde_json::json!([[i, i + 1], [i + 2, [i + 3, i + 4]]]))
+        .collect();
+    let nested = Variable::from_json(&serde_json::to_string(&nested).unwrap()).unwrap();
+    let expr = runtime.compile("flatten_deep(@)").unwrap();
+    group.bench_with_input(
+        BenchmarkId::new("flatten_deep", "nested"),
+        &nested,
+        |b, data| b.iter(|| expr.search(black_box(data))),
+    );
+
+    // group_by - array of objects
+    let users: Vec<serde_json::Value> = (0..100)
+        .map(
+            |i| serde_json::json!({"role": format!("role{}", i % 5), "name": format!("user{}", i)}),
+        )
+        .collect();
+    let users = Variable::from_json(&serde_json::to_string(&users).unwrap()).unwrap();
+    let expr = runtime.compile(r#"group_by(@, `"role"`)"#).unwrap();
+    group.bench_with_input(BenchmarkId::new("group_by", "100"), &users, |b, data| {
+        b.iter(|| expr.search(black_box(data)))
+    });
+
+    // Set operations - intersection, difference, union
+    let arr1: Vec<i32> = (0..100).collect();
+    let arr2: Vec<i32> = (50..150).collect();
+    let sets = Variable::from_json(&format!(
+        r#"{{"a": {}, "b": {}}}"#,
+        serde_json::to_string(&arr1).unwrap(),
+        serde_json::to_string(&arr2).unwrap()
+    ))
+    .unwrap();
+
+    let expr = runtime.compile("intersection(a, b)").unwrap();
+    group.bench_with_input(BenchmarkId::new("intersection", "100"), &sets, |b, data| {
+        b.iter(|| expr.search(black_box(data)))
+    });
+
+    let expr = runtime.compile("difference(a, b)").unwrap();
+    group.bench_with_input(BenchmarkId::new("difference", "100"), &sets, |b, data| {
+        b.iter(|| expr.search(black_box(data)))
+    });
+
+    let expr = runtime.compile("union(a, b)").unwrap();
+    group.bench_with_input(BenchmarkId::new("union", "100"), &sets, |b, data| {
+        b.iter(|| expr.search(black_box(data)))
+    });
+
+    // frequencies
+    let with_repeats: Vec<i32> = (0..100).flat_map(|x| vec![x % 10; 3]).collect();
+    let with_repeats = Variable::from_json(&serde_json::to_string(&with_repeats).unwrap()).unwrap();
+    let expr = runtime.compile("frequencies(@)").unwrap();
+    group.bench_with_input(
+        BenchmarkId::new("frequencies", "300"),
+        &with_repeats,
+        |b, data| b.iter(|| expr.search(black_box(data))),
+    );
+
+    // repeat_array and cycle (Phase 3 functions)
+    let expr = runtime.compile("repeat_array(`1`, `100`)").unwrap();
+    let null_data = Variable::Null;
+    group.bench_with_input(
+        BenchmarkId::new("repeat_array", "100"),
+        &null_data,
+        |b, data| b.iter(|| expr.search(black_box(data))),
+    );
+
+    let small_arr = Variable::from_json("[1, 2, 3]").unwrap();
+    let expr = runtime.compile("cycle(@, `50`)").unwrap();
+    group.bench_with_input(BenchmarkId::new("cycle", "150"), &small_arr, |b, data| {
+        b.iter(|| expr.search(black_box(data)))
+    });
+
+    group.finish();
+}
+
+fn bench_object_functions(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("object");
+
+    // deep_merge - nested objects
+    let obj = Variable::from_json(r#"{"a": {"b": {"c": 1}}, "d": {"e": 2}, "f": 3}"#).unwrap();
+    let expr = runtime
+        .compile(r#"deep_merge(@, `{"a": {"b": {"x": 9}}, "d": {"y": 8}}`)"#)
+        .unwrap();
+    group.bench_function("deep_merge", |b| b.iter(|| expr.search(black_box(&obj))));
+
+    // flatten_keys - nested object
+    let nested_obj =
+        Variable::from_json(r#"{"a": {"b": {"c": 1, "d": 2}, "e": 3}, "f": {"g": 4}}"#).unwrap();
+    let expr = runtime.compile("flatten_keys(@)").unwrap();
+    group.bench_function("flatten_keys", |b| {
+        b.iter(|| expr.search(black_box(&nested_obj)))
+    });
+
+    // unflatten_keys
+    let flat_obj = Variable::from_json(r#"{"a.b.c": 1, "a.b.d": 2, "a.e": 3, "f.g": 4}"#).unwrap();
+    let expr = runtime.compile("unflatten_keys(@)").unwrap();
+    group.bench_function("unflatten_keys", |b| {
+        b.iter(|| expr.search(black_box(&flat_obj)))
+    });
+
+    // pick - select specific keys
+    let large_obj: serde_json::Map<String, serde_json::Value> = (0..50)
+        .map(|i| (format!("key{}", i), serde_json::json!(i)))
+        .collect();
+    let large_obj = Variable::from_json(&serde_json::to_string(&large_obj).unwrap()).unwrap();
+    let expr = runtime
+        .compile(r#"pick(@, ['key1', 'key5', 'key10', 'key20', 'key30'])"#)
+        .unwrap();
+    group.bench_with_input(BenchmarkId::new("pick", "50"), &large_obj, |b, data| {
+        b.iter(|| expr.search(black_box(data)))
+    });
+
+    // omit - exclude specific keys
+    let expr = runtime
+        .compile(r#"omit(@, ['key1', 'key5', 'key10', 'key20', 'key30'])"#)
+        .unwrap();
+    group.bench_with_input(BenchmarkId::new("omit", "50"), &large_obj, |b, data| {
+        b.iter(|| expr.search(black_box(data)))
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "datetime")]
+fn bench_datetime_functions(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("datetime");
+
+    // parse_date
+    let date_str = Variable::String("2024-01-15".to_string());
+    let expr = runtime.compile("parse_date(@, '%Y-%m-%d')").unwrap();
+    group.bench_function("parse_date", |b| {
+        b.iter(|| expr.search(black_box(&date_str)))
+    });
+
+    // format_date
+    let timestamp = Variable::from_json("1705276800").unwrap();
+    let expr = runtime.compile("format_date(@, '%Y-%m-%d')").unwrap();
+    group.bench_function("format_date", |b| {
+        b.iter(|| expr.search(black_box(&timestamp)))
+    });
+
+    // date_diff
+    let dates = Variable::from_json(r#"[1705276800, 1704067200]"#).unwrap();
+    let expr = runtime.compile("date_diff(@[0], @[1], 'days')").unwrap();
+    group.bench_function("date_diff", |b| b.iter(|| expr.search(black_box(&dates))));
+
+    // relative_time
+    let expr = runtime.compile("relative_time(@)").unwrap();
+    group.bench_function("relative_time", |b| {
+        b.iter(|| expr.search(black_box(&timestamp)))
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "path")]
+fn bench_path_functions(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("path");
+
+    let nested = Variable::from_json(r#"{"a": {"b": {"c": {"d": {"e": 1}}}}}"#).unwrap();
+
+    // get_path - deep access
+    let expr = runtime.compile(r#"get_path(@, `"a.b.c.d.e"`)"#).unwrap();
+    group.bench_function("get_path/deep", |b| {
+        b.iter(|| expr.search(black_box(&nested)))
+    });
+
+    // set_path
+    let expr = runtime
+        .compile(r#"set_path(@, `"a.b.c.d.e"`, `999`)"#)
+        .unwrap();
+    group.bench_function("set_path/deep", |b| {
+        b.iter(|| expr.search(black_box(&nested)))
+    });
+
+    // has_path
+    let expr = runtime.compile(r#"has_path(@, `"a.b.c.d.e"`)"#).unwrap();
+    group.bench_function("has_path/deep", |b| {
+        b.iter(|| expr.search(black_box(&nested)))
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "encoding")]
+fn bench_encoding_functions(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("encoding");
+
+    let data = Variable::String("Hello, World! This is a test string.".to_string());
+
+    let expr = runtime.compile("base64_encode(@)").unwrap();
+    group.bench_function("base64_encode", |b| {
+        b.iter(|| expr.search(black_box(&data)))
+    });
+
+    let encoded = Variable::String("SGVsbG8sIFdvcmxkISBUaGlzIGlzIGEgdGVzdCBzdHJpbmcu".to_string());
+    let expr = runtime.compile("base64_decode(@)").unwrap();
+    group.bench_function("base64_decode", |b| {
+        b.iter(|| expr.search(black_box(&encoded)))
+    });
+
+    // JWT decode (without verification)
+    let jwt = Variable::String(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".to_string(),
+    );
+    let expr = runtime.compile("jwt_decode(@)").unwrap();
+    group.bench_function("jwt_decode", |b| b.iter(|| expr.search(black_box(&jwt))));
+
+    group.finish();
+}
+
+#[cfg(feature = "validation")]
+fn bench_validation_functions(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("validation");
+
+    let email = Variable::String("user@example.com".to_string());
+    let expr = runtime.compile("is_email(@)").unwrap();
+    group.bench_function("is_email", |b| b.iter(|| expr.search(black_box(&email))));
+
+    let url = Variable::String("https://example.com/path?query=value".to_string());
+    let expr = runtime.compile("is_url(@)").unwrap();
+    group.bench_function("is_url", |b| b.iter(|| expr.search(black_box(&url))));
+
+    let uuid = Variable::String("550e8400-e29b-41d4-a716-446655440000".to_string());
+    let expr = runtime.compile("is_uuid(@)").unwrap();
+    group.bench_function("is_uuid", |b| b.iter(|| expr.search(black_box(&uuid))));
+
+    let ip = Variable::String("192.168.1.1".to_string());
+    let expr = runtime.compile("is_ipv4(@)").unwrap();
+    group.bench_function("is_ipv4", |b| b.iter(|| expr.search(black_box(&ip))));
+
+    group.finish();
+}
+
+fn bench_type_functions(c: &mut Criterion) {
+    let runtime = create_runtime();
+    let mut group = c.benchmark_group("type");
+
+    let string = Variable::String("42".to_string());
+    let expr = runtime.compile("to_number(@)").unwrap();
+    group.bench_function("to_number", |b| b.iter(|| expr.search(black_box(&string))));
+
+    let number = Variable::from_json("42").unwrap();
+    let expr = runtime.compile("to_string(@)").unwrap();
+    group.bench_function("to_string", |b| b.iter(|| expr.search(black_box(&number))));
+
+    let expr = runtime.compile("type_of(@)").unwrap();
+    group.bench_function("type_of/number", |b| {
+        b.iter(|| expr.search(black_box(&number)))
+    });
+
+    let arr = Variable::from_json("[1, 2, 3]").unwrap();
+    group.bench_function("type_of/array", |b| b.iter(|| expr.search(black_box(&arr))));
 
     group.finish();
 }
@@ -425,6 +733,8 @@ criterion_group!(
     core_benches,
     bench_string_functions,
     bench_array_functions,
+    bench_object_functions,
+    bench_type_functions,
     bench_math_functions,
     bench_registration
 );
@@ -453,6 +763,21 @@ criterion_group!(multi_match_benches, bench_multi_match_functions);
 #[cfg(feature = "jsonpatch")]
 criterion_group!(jsonpatch_benches, bench_jsonpatch_functions);
 
+#[cfg(feature = "regex")]
+criterion_group!(regex_benches, bench_regex_functions);
+
+#[cfg(feature = "datetime")]
+criterion_group!(datetime_benches, bench_datetime_functions);
+
+#[cfg(feature = "path")]
+criterion_group!(path_benches, bench_path_functions);
+
+#[cfg(feature = "encoding")]
+criterion_group!(encoding_benches, bench_encoding_functions);
+
+#[cfg(feature = "validation")]
+criterion_group!(validation_benches, bench_validation_functions);
+
 // Full feature set
 #[cfg(all(
     feature = "hash",
@@ -462,7 +787,12 @@ criterion_group!(jsonpatch_benches, bench_jsonpatch_functions);
     feature = "expression",
     feature = "text",
     feature = "multi-match",
-    feature = "jsonpatch"
+    feature = "jsonpatch",
+    feature = "regex",
+    feature = "datetime",
+    feature = "path",
+    feature = "encoding",
+    feature = "validation"
 ))]
 criterion_main!(
     core_benches,
@@ -473,7 +803,12 @@ criterion_main!(
     expression_benches,
     text_benches,
     multi_match_benches,
-    jsonpatch_benches
+    jsonpatch_benches,
+    regex_benches,
+    datetime_benches,
+    path_benches,
+    encoding_benches,
+    validation_benches
 );
 
 // Fallback for minimal feature sets
@@ -485,6 +820,11 @@ criterion_main!(
     feature = "expression",
     feature = "text",
     feature = "multi-match",
-    feature = "jsonpatch"
+    feature = "jsonpatch",
+    feature = "regex",
+    feature = "datetime",
+    feature = "path",
+    feature = "encoding",
+    feature = "validation"
 )))]
 criterion_main!(core_benches);


### PR DESCRIPTION
## Summary

Significantly expands benchmark coverage from ~35 to ~70+ functions, addressing issue #388.

## New Benchmarks Added

### Array Functions
- `flatten_deep` - nested arrays
- `group_by` - array of objects by field
- `intersection`, `difference`, `union` - set operations on arrays
- `frequencies` - value counting
- `repeat_array`, `cycle` - Phase 3 Clojure functions

### Object Functions
- `deep_merge` - nested object merging
- `flatten_keys`, `unflatten_keys` - key transformation
- `pick`, `omit` - key selection/exclusion

### String Functions  
- `trim`, `pad_left`, `pad_right`

### Regex Functions (feature-gated)
- `regex_match` (simple and large text)
- `regex_replace`

### Datetime Functions (feature-gated)
- `parse_date`, `format_date`, `date_diff`, `relative_time`

### Path Functions (feature-gated)
- `get_path`, `set_path`, `has_path` (deep paths)

### Encoding Functions (feature-gated)
- `base64_encode`, `base64_decode`, `jwt_decode`

### Validation Functions (feature-gated)
- `is_email`, `is_url`, `is_uuid`, `is_ipv4`

### Type Functions
- `to_number`, `to_string`, `type_of`

## Testing

- Benchmarks compile with all features: `cargo build --all-features --benches`
- All tests pass
- Clippy passes

Closes #388