### PR TITLE
fix: correct package name in release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,7 +9,7 @@ pr_labels = ["release"]
 
 # Main library - release-plz creates GitHub release (no binaries needed)
 [[package]]
-name = "jmespath_extensions"
+name = "jmespath-extensions"
 publish = true
 git_release_enable = true
 git_tag_name = "v{{ version }}"


### PR DESCRIPTION
## Summary
Fixes the release-plz GitHub Action failure by correcting a typo in the package name.

## Problem
The release-plz action was failing with:
```
The following overrides are not present in the workspace: `jmespath_extensions`. Check for typos
```

## Solution
Changed `jmespath_extensions` (underscore) to `jmespath-extensions` (hyphen) to match the actual package name in Cargo.toml.

## Testing
- Ran cargo fmt, clippy, and tests locally - all pass