### PR TITLE
docs: add jpx-server Docker image to MCP setup docs

### DIFF
--- a/crates/jpx/README.md
+++ b/crates/jpx/README.md
@@ -169,7 +169,20 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-Or use Docker (no installation required):
+Or use Docker with the dedicated server image (no installation required):
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/jpx-server"]
+    }
+  }
+}
+```
+
+You can also use the CLI image with the `mcp` subcommand:
 
 ```json
 {

--- a/docs/src/server/mcp/setup.md
+++ b/docs/src/server/mcp/setup.md
@@ -15,9 +15,24 @@ Configure jpx as an MCP server for Claude Desktop.
 
 ## Configuration
 
-### Docker
+### Docker (Recommended)
 
-The simplest way to run jpx as an MCP server:
+The simplest way to run jpx as an MCP server using the dedicated server image:
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/jpx-server"]
+    }
+  }
+}
+```
+
+Available for `linux/amd64` and `linux/arm64`.
+
+Alternatively, you can use the CLI image with the `mcp` subcommand:
 
 ```json
 {


### PR DESCRIPTION
## Summary
Updates the MCP setup documentation to reference the new dedicated `jpx-server` Docker image.

## Changes
- **docs/src/server/mcp/setup.md**: Updated Docker config to show `jpx-server` as the recommended approach
- **crates/jpx/README.md**: Added `jpx-server` image as primary Docker option for MCP

Both docs now show:
1. **Recommended**: `ghcr.io/joshrotenberg/jpx-server` - dedicated server image
2. **Alternative**: `ghcr.io/joshrotenberg/jpx mcp` - CLI with mcp subcommand