### PR TITLE
fix: use underscore in release-plz.toml package name

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,7 +9,7 @@ pr_labels = ["release"]
 
 # Main library - release-plz creates GitHub release (no binaries needed)
 [[package]]
-name = "jmespath-extensions"
+name = "jmespath_extensions"
 publish = true
 git_release_enable = true
 git_tag_name = "v{{ version }}"


### PR DESCRIPTION
The package name on crates.io is `jmespath_extensions` (underscore), not `jmespath-extensions` (hyphen).

This was incorrectly changed in PR #393 before PR #394 fixed the Cargo.toml.