### PR TITLE
fix: correct README path for jmespath_extensions crate

### DIFF
--- a/crates/jmespath-extensions/Cargo.toml
+++ b/crates/jmespath-extensions/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 description = "Extended functions for JMESPath queries - 400+ functions for strings, arrays, dates, hashing, encoding, geo, and more"
 documentation = "https://docs.rs/jmespath_extensions"
-readme = "../README.md"
+readme = "../../README.md"
 keywords = ["jmespath", "json", "query", "transform", "filter"]
 categories = ["data-structures", "parsing", "text-processing"]
 


### PR DESCRIPTION
The crate is at `crates/jmespath-extensions/` so the path to the root README.md should be `../../README.md`, not `../README.md`.

This was causing release-plz to fail with:
```
error: readme `../README.md` does not appear to exist
```

Verified with `cargo package -p jmespath_extensions` which now succeeds.