### PR TITLE
chore: bump jmespath_extensions to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "jmespath_extensions"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 
 # Internal crates
-jmespath-extensions = { path = "crates/jmespath-extensions", version = "0.8.2", package = "jmespath_extensions" }
+jmespath-extensions = { path = "crates/jmespath-extensions", version = "0.8.3", package = "jmespath_extensions" }
 jpx-engine = { path = "crates/jpx-engine", version = "0.1.0" }
 
 # Config for 'cargo dist'

--- a/crates/jmespath-extensions/Cargo.toml
+++ b/crates/jmespath-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmespath_extensions"
-version = "0.8.2"
+version = "0.8.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Patch release to establish a clean baseline for release-plz after the crates/ directory reorganization fixed the README path.

After this merges, release-plz should be able to compare packages correctly since the new commit has the fixed `../../README.md` path.