### PR TITLE
fix: disable semver_check to bypass broken commit comparison

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,10 @@ name = "jmespath_extensions"
 publish = true
 git_release_enable = true
 git_tag_name = "v{{ version }}"
+# Disable semver check - the crates/ directory reorganization broke comparison
+# against previous commits (README path changed from ../README.md to ../../README.md).
+# Can be re-enabled after 0.8.3 is published and becomes the comparison baseline.
+semver_check = false
 
 # CLI tool - separate versioning, let cargo-dist handle GitHub releases
 [[package]]


### PR DESCRIPTION
Release-plz compares against commit db58269 which has the old README path (`../README.md`). Disabling `semver_check` skips this comparison and allows the release to proceed.

Can be re-enabled after 0.8.3 is published and becomes the new comparison baseline.