### PR TITLE
fix: add version to jpx-engine dependency in jpx-server

### DIFF
--- a/crates/jpx-server/Cargo.toml
+++ b/crates/jpx-server/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Engine
-jpx-engine = { path = "../jpx-engine" }
+jpx-engine = { version = "0.1.0", path = "../jpx-engine" }
 
 # Core
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Required for publishing to crates.io - path-only dependencies are not allowed when publishing.

This allows `cargo publish -p jpx-server` to succeed.