### PR TITLE
fix: add version to jpx-engine dependency in jpx

### DIFF
--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true, features = ["derive"] }
 [dependencies]
 jmespath.workspace = true
 jmespath-extensions = { workspace = true, features = ["full", "query-library"] }
-jpx-engine = { path = "../jpx-engine" }
+jpx-engine = { version = "0.1", path = "../jpx-engine" }
 clap.workspace = true
 clap_complete.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Required for publishing to crates.io - path-only dependencies are not allowed when publishing.

This allows `cargo publish -p jpx` to succeed. Same fix as #402 for jpx-server.