### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow",
  "jmespath",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "jpx-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crates
 jmespath-extensions = { path = "crates/jmespath-extensions", version = "0.8.3", package = "jmespath_extensions" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.1.0" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.1.1" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-engine-v0.1.0...jpx-engine-v0.1.1) - 2026-01-18
+
+### Fixed
+
+- Docker CLI workflow and add jpx-engine changelog ([#404](https://github.com/joshrotenberg/jmespath-extensions/pull/404))
+
 ## [0.1.0] - 2026-01-18
 
 ### Added

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/jpx-server/CHANGELOG.md
+++ b/crates/jpx-server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-server-v0.1.0...jpx-server-v0.1.1) - 2026-01-18
+
+### Other
+
+- updated the following local packages: jpx-engine
+
 ## [0.1.0](https://github.com/joshrotenberg/jmespath-extensions/releases/tag/jpx-server-v0.1.0) - 2026-01-18
 
 ### Fixed

--- a/crates/jpx-server/Cargo.toml
+++ b/crates/jpx-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-server"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Engine
-jpx-engine = { version = "0.1.0", path = "../jpx-engine" }
+jpx-engine = { version = "0.1.1", path = "../jpx-engine" }
 
 # Core
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `jpx-engine`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `jpx-server`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-engine`

<blockquote>

## [0.1.1](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-engine-v0.1.0...jpx-engine-v0.1.1) - 2026-01-18

### Fixed

- Docker CLI workflow and add jpx-engine changelog ([#404](https://github.com/joshrotenberg/jmespath-extensions/pull/404))
</blockquote>

## `jpx-server`

<blockquote>

## [0.1.1](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-server-v0.1.0...jpx-server-v0.1.1) - 2026-01-18

### Other

- updated the following local packages: jpx-engine
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).