### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arrow",
  "jmespath",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "jpx-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crates
 jmespath-extensions = { path = "crates/jmespath-extensions", version = "0.8.3", package = "jmespath_extensions" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.1.1" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.1.2" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-engine-v0.1.1...jpx-engine-v0.1.2) - 2026-01-19
+
+### Fixed
+
+- *(mcp)* add proper type schema to register_discovery spec parameter ([#409](https://github.com/joshrotenberg/jmespath-extensions/pull/409))
+
 ## [0.1.1](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-engine-v0.1.0...jpx-engine-v0.1.1) - 2026-01-18
 
 ### Fixed

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/jpx-server/CHANGELOG.md
+++ b/crates/jpx-server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-server-v0.1.1...jpx-server-v0.1.2) - 2026-01-19
+
+### Fixed
+
+- *(mcp)* add proper type schema to register_discovery spec parameter ([#409](https://github.com/joshrotenberg/jmespath-extensions/pull/409))
+
 ## [0.1.1](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-server-v0.1.0...jpx-server-v0.1.1) - 2026-01-18
 
 ### Other

--- a/crates/jpx-server/Cargo.toml
+++ b/crates/jpx-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-server"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Engine
-jpx-engine = { version = "0.1.1", path = "../jpx-engine", features = ["schema"] }
+jpx-engine = { version = "0.1.2", path = "../jpx-engine", features = ["schema"] }
 
 # Core
 serde = { workspace = true, features = ["derive"] }

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.2.0...jpx-v0.2.1) - 2026-01-19
+
+### Other
+
+- update MCP references to use jpx-server instead of jpx mcp ([#408](https://github.com/joshrotenberg/jmespath-extensions/pull/408))
+
 ## [0.2.0](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.1.18...jpx-v0.2.0) - 2026-01-18
 
 ### Added

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jpx-engine`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `jpx`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `jpx-server`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-engine`

<blockquote>

## [0.1.2](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-engine-v0.1.1...jpx-engine-v0.1.2) - 2026-01-19

### Fixed

- *(mcp)* add proper type schema to register_discovery spec parameter ([#409](https://github.com/joshrotenberg/jmespath-extensions/pull/409))
</blockquote>

## `jpx`

<blockquote>

## [0.2.1](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-v0.2.0...jpx-v0.2.1) - 2026-01-19

### Other

- update MCP references to use jpx-server instead of jpx mcp ([#408](https://github.com/joshrotenberg/jmespath-extensions/pull/408))
</blockquote>

## `jpx-server`

<blockquote>

## [0.1.2](https://github.com/joshrotenberg/jmespath-extensions/compare/jpx-server-v0.1.1...jpx-server-v0.1.2) - 2026-01-19

### Fixed

- *(mcp)* add proper type schema to register_discovery spec parameter ([#409](https://github.com/joshrotenberg/jmespath-extensions/pull/409))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).