### PR TITLE
docs: update MCP references to use jpx-server

### DIFF
--- a/crates/jpx/README.md
+++ b/crates/jpx/README.md
@@ -94,143 +94,17 @@ cargo install --path . --no-default-features
 
 ## MCP Server (AI Assistant Integration)
 
-jpx can run as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server, allowing AI assistants like Claude to use JMESPath for JSON querying and transformation.
-
-### Building with MCP Support
-
-MCP support is included by default. Simply build:
+For MCP (Model Context Protocol) support, use the dedicated [`jpx-server`](https://crates.io/crates/jpx-server) package:
 
 ```bash
-cargo build -p jpx --release
+# Install
+cargo install jpx-server
+
+# Or use Docker
+docker run -i --rm ghcr.io/joshrotenberg/jpx-server
 ```
 
-To build without MCP support (smaller binary):
-
-```bash
-cargo build -p jpx --no-default-features --release
-```
-
-### Running the Server
-
-```bash
-jpx mcp
-```
-
-### MCP Tools (17 total)
-
-**Discovery** - Find and explore functionality:
-
-| Tool | Description |
-|------|-------------|
-| `search` | Fuzzy search functions by name, description, category, or signature |
-| `similar` | Find functions related to a specified function |
-| `functions` | List available functions (with optional category filter) |
-| `describe` | Get detailed info for a specific function |
-| `categories` | List all function categories |
-
-**Data Analysis** - Understand JSON structure:
-
-| Tool | Description |
-|------|-------------|
-| `stats` | Analyze JSON structure (type, size, depth, field analysis) |
-| `paths` | Extract all paths in dot notation (e.g., `users[0].name`) |
-| `keys` | Extract object keys (optionally recursive with dot notation) |
-
-**Querying** - Evaluate expressions:
-
-| Tool | Description |
-|------|-------------|
-| `evaluate` | Run JMESPath expressions against JSON input |
-| `evaluate_file` | Query JSON files directly from disk (with security checks) |
-| `batch_evaluate` | Run multiple expressions against the same input |
-| `validate` | Check expression syntax without executing |
-
-**JSON Utilities** - Transform and manipulate:
-
-| Tool | Description |
-|------|-------------|
-| `format` | Pretty-print JSON with configurable indentation |
-| `diff` | Generate RFC 6902 JSON Patch between two documents |
-| `patch` | Apply RFC 6902 JSON Patch operations |
-| `merge` | Apply RFC 7396 JSON Merge Patch |
-
-### Claude Desktop Configuration
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
-
-```json
-{
-  "mcpServers": {
-    "jpx": {
-      "command": "/path/to/jpx",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-Or use Docker with the dedicated server image (no installation required):
-
-```json
-{
-  "mcpServers": {
-    "jpx": {
-      "command": "docker",
-      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/jpx-server"]
-    }
-  }
-}
-```
-
-You can also use the CLI image with the `mcp` subcommand:
-
-```json
-{
-  "mcpServers": {
-    "jpx": {
-      "command": "docker",
-      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/jpx", "mcp"]
-    }
-  }
-}
-```
-
-### Example Usage
-
-Once configured, Claude can use jpx to query JSON data:
-
-```
-User: I have this JSON: {"users": [{"name": "alice", "age": 30}, {"name": "bob", "age": 25}]}
-      Get the names of users over 28.
-
-Claude: [Uses jpx.evaluate with expression "users[?age > `28`].name"]
-        Result: ["alice"]
-```
-
-#### More MCP Examples
-
-**Query a file directly:**
-```
-Claude: [Uses jpx.evaluate_file with file_path="/data/users.json", expression="users[*].email"]
-```
-
-**Batch multiple queries:**
-```
-Claude: [Uses jpx.batch_evaluate with input and expressions=["length(users)", "users[0].name", "max(users[*].age)"]]
-        Result: {results: [{expression: "length(users)", result: 10}, ...]}
-```
-
-**Compare JSON documents (RFC 6902):**
-```
-Claude: [Uses jpx.diff with source and target documents]
-        Result: [{"op": "replace", "path": "/name", "value": "bob"}, {"op": "add", "path": "/age", "value": 30}]
-```
-
-**Explore JSON structure:**
-```
-Claude: [Uses jpx.keys with input and recursive=true]
-        Result: ["user", "user.name", "user.profile", "user.profile.settings"]
-```
+See the [MCP documentation](https://joshrotenberg.github.io/jmespath-extensions/server/mcp/overview.html) for setup instructions with Claude Desktop.
 
 ## Usage
 

--- a/docs/src/cli/strict-mode.md
+++ b/docs/src/cli/strict-mode.md
@@ -86,14 +86,14 @@ The `unique` function is an extension, while `sort` is standard.
 
 ## MCP Server Strict Mode
 
-The MCP server also supports strict mode. When configured, the `jpx-strict` server provides only standard JMESPath functions:
+The MCP server also supports strict mode. When configured with `--strict`, only standard JMESPath functions are available:
 
 ```json
 {
   "mcpServers": {
     "jpx-strict": {
-      "command": "jpx",
-      "args": ["mcp", "--strict"]
+      "command": "jpx-server",
+      "args": ["--strict"]
     }
   }
 }

--- a/docs/src/server/mcp/setup.md
+++ b/docs/src/server/mcp/setup.md
@@ -1,15 +1,14 @@
 # Setup with Claude Desktop
 
-Configure jpx as an MCP server for Claude Desktop.
+Configure jpx-server as an MCP server for Claude Desktop.
 
 ## Prerequisites
 
-1. Install jpx (MCP support is included by default):
+1. Install jpx-server:
    ```bash
-   brew install joshrotenberg/brew/jpx
-   # or
-   cargo install jpx
+   cargo install jpx-server
    ```
+   Or use Docker (no installation required).
 
 2. Have Claude Desktop installed
 
@@ -32,19 +31,6 @@ The simplest way to run jpx as an MCP server using the dedicated server image:
 
 Available for `linux/amd64` and `linux/arm64`.
 
-Alternatively, you can use the CLI image with the `mcp` subcommand:
-
-```json
-{
-  "mcpServers": {
-    "jpx": {
-      "command": "docker",
-      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/jpx", "mcp"]
-    }
-  }
-}
-```
-
 ### macOS
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
@@ -53,21 +39,19 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 {
   "mcpServers": {
     "jpx": {
-      "command": "jpx",
-      "args": ["mcp"]
+      "command": "jpx-server"
     }
   }
 }
 ```
 
-If jpx is not in your PATH, use the full path:
+If jpx-server is not in your PATH, use the full path:
 
 ```json
 {
   "mcpServers": {
     "jpx": {
-      "command": "/opt/homebrew/bin/jpx",
-      "args": ["mcp"]
+      "command": "/Users/yourname/.cargo/bin/jpx-server"
     }
   }
 }
@@ -81,8 +65,7 @@ Edit `%APPDATA%\Claude\claude_desktop_config.json`:
 {
   "mcpServers": {
     "jpx": {
-      "command": "C:\\path\\to\\jpx.exe",
-      "args": ["mcp"]
+      "command": "C:\\path\\to\\jpx-server.exe"
     }
   }
 }
@@ -110,8 +93,21 @@ To use only standard JMESPath functions (no extensions):
 {
   "mcpServers": {
     "jpx": {
-      "command": "jpx",
-      "args": ["mcp", "--strict"]
+      "command": "jpx-server",
+      "args": ["--strict"]
+    }
+  }
+}
+```
+
+Or with Docker:
+
+```json
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/jpx-server", "--strict"]
     }
   }
 }
@@ -119,9 +115,9 @@ To use only standard JMESPath functions (no extensions):
 
 ## Troubleshooting
 
-### jpx not found
+### jpx-server not found
 
-Make sure jpx is in your PATH, or use the full path in the config.
+Make sure jpx-server is in your PATH, or use the full path in the config.
 
 ### Tools not appearing
 


### PR DESCRIPTION
The jpx CLI no longer includes the `mcp` subcommand - MCP server functionality is now in the separate `jpx-server` binary.

## Changes

- **docs/src/server/mcp/setup.md**: Updated all examples to use `jpx-server` instead of `jpx mcp`
- **docs/src/cli/strict-mode.md**: Updated MCP example to use `jpx-server --strict`
- **crates/jpx/README.md**: Simplified MCP section to point users to `jpx-server` package

This removes documentation for the obsolete `jpx mcp` subcommand that was removed in v0.2.0.