### PR TITLE
fix: correct docs.rs badge URL to use underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jmespath-extensions
 
-[![Crates.io](https://img.shields.io/crates/v/jmespath-extensions.svg)](https://crates.io/crates/jmespath-extensions)
-[![Documentation](https://docs.rs/jmespath-extensions/badge.svg)](https://docs.rs/jmespath-extensions)
+[![Crates.io](https://img.shields.io/crates/v/jmespath_extensions.svg)](https://crates.io/crates/jmespath_extensions)
+[![Documentation](https://docs.rs/jmespath_extensions/badge.svg)](https://docs.rs/jmespath_extensions)
 [![CI](https://github.com/joshrotenberg/jmespath-extensions/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/jmespath-extensions/actions/workflows/ci.yml)
 
 Extended JMESPath with 400+ functions. Available as a CLI, MCP server, Rust library, and Python bindings.


### PR DESCRIPTION
The crate is published as `jmespath_extensions` (underscore), not `jmespath-extensions` (hyphen). This fixes the docs badge showing 'not found'.