### PR TITLE
chore: skip CI for docs-only and markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "LICENSE-*"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "LICENSE-*"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Add `paths-ignore` to CI workflow to skip running tests, clippy, etc. when only `docs/` or markdown files change.

This saves CI minutes since the docs workflow already handles documentation deployment separately.